### PR TITLE
feat: Select/deselect all (or all but one) labels

### DIFF
--- a/src/components/LeftDrawer.tsx
+++ b/src/components/LeftDrawer.tsx
@@ -33,6 +33,7 @@ export default function LeftDrawer({ drawerContent }: Props): ReactElement {
         open={isOpen}
         onClose={toggleDrawer}
         onOpen={toggleDrawer}
+        keepMounted
       >
         <AppBar position="static">
           <Toolbar>

--- a/src/searchAndSort/LabelsAccordion.tsx
+++ b/src/searchAndSort/LabelsAccordion.tsx
@@ -48,7 +48,7 @@ export default function LabelsAccordion({
   const style = useStyles();
   const [selectedLabels, setSelectedLabels] = useState(imageLabels);
 
-  const addDelLabel = (label: string) => (): void => {
+  const toggleLabelSelection = (label: string) => (): void => {
     // Add label to list of selectedLabels if not present,
     // delete from it, if present.
     setSelectedLabels((prevState) => {
@@ -61,6 +61,19 @@ export default function LabelsAccordion({
       return prevLabels;
     });
   };
+
+  const toggleLabelAndSelectAll = (label: string) => (): void => {
+    // Select label if not selected and deselect every other label (and vice versa).
+    let newSelectedLabels = [];
+    if (selectedLabels.includes(label)) {
+      newSelectedLabels = imageLabels.filter((l) => l !== label);
+    } else {
+      newSelectedLabels.push(label);
+    }
+
+    setSelectedLabels(newSelectedLabels);
+  };
+
   useEffect(() => {
     callback(selectedLabels);
   }, [selectedLabels]);
@@ -81,7 +94,8 @@ export default function LabelsAccordion({
               key={label}
               dense
               button
-              onClick={addDelLabel(label)}
+              onDoubleClick={toggleLabelAndSelectAll(label)}
+              onClick={toggleLabelSelection(label)}
               className={style.listItem}
             >
               {selectedLabels.includes(label) ? (

--- a/src/searchAndSort/LabelsAccordion.tsx
+++ b/src/searchAndSort/LabelsAccordion.tsx
@@ -8,26 +8,47 @@ import {
   List,
   ListItem,
   ListItemText,
+  IconButton,
 } from "@material-ui/core";
-import { ExpandMore, Label, LabelOutlined } from "@material-ui/icons";
+import {
+  ExpandMore,
+  Label,
+  LabelOutlined,
+  LibraryAddCheckOutlined,
+  HighlightOffOutlined,
+} from "@material-ui/icons";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    root: {
-      width: "100%",
+    accordionDetails: {
+      display: "block",
       maxWidth: 300,
     },
     title: {
       paddingLeft: theme.spacing(1),
     },
-    listItem: {
-      paddingLeft: theme.spacing(1),
+    labelsList: { display: "flex", flexDirection: "row", flexWrap: "wrap" },
+    labelsListItem: {
+      paddingLeft: theme.spacing(2),
+      width: "auto",
     },
-    text: {
-      paddingLeft: theme.spacing(4),
-    },
-    icon: {
+    labelIcon: {
       color: theme.palette.primary.dark,
+    },
+    labelText: {
+      paddingLeft: theme.spacing(2),
+    },
+    buttonsList: { display: "flex", flexDirection: "row", flexWrap: "nowrap" },
+    buttonsListItem: {
+      padding: theme.spacing(1),
+      width: "auto",
+    },
+    iconButton: {
+      color: theme.palette.primary.dark,
+    },
+    infoOnHover: {
+      color: theme.palette.primary.light,
+      fontStyle: "italic",
     },
   })
 );
@@ -47,6 +68,7 @@ export default function LabelsAccordion({
 }: Props): ReactElement {
   const style = useStyles();
   const [selectedLabels, setSelectedLabels] = useState(imageLabels);
+  const [infoOnHover, setInfoOnHover] = useState("");
 
   const toggleLabelSelection = (label: string) => (): void => {
     // Add label to list of selectedLabels if not present,
@@ -74,12 +96,20 @@ export default function LabelsAccordion({
     setSelectedLabels(newSelectedLabels);
   };
 
+  const selectAllLabels = () => {
+    setSelectedLabels(imageLabels);
+  };
+
+  const deselectAllLabels = () => {
+    setSelectedLabels([]);
+  };
+
   useEffect(() => {
     callback(selectedLabels);
   }, [selectedLabels]);
 
   useEffect(() => {
-    setSelectedLabels(imageLabels);
+    selectAllLabels();
   }, [imageLabels]);
 
   return (
@@ -87,8 +117,8 @@ export default function LabelsAccordion({
       <AccordionSummary expandIcon={<ExpandMore />} id="labels-toolbox">
         <Typography className={style.title}>Image labels</Typography>
       </AccordionSummary>
-      <AccordionDetails>
-        <List component="div" disablePadding className={style.root}>
+      <AccordionDetails className={style.accordionDetails}>
+        <List component="div" disablePadding className={style.labelsList}>
           {imageLabels.map((label) => (
             <ListItem
               key={label}
@@ -96,16 +126,38 @@ export default function LabelsAccordion({
               button
               onDoubleClick={toggleLabelAndSelectAll(label)}
               onClick={toggleLabelSelection(label)}
-              className={style.listItem}
+              className={style.labelsListItem}
             >
               {selectedLabels.includes(label) ? (
-                <Label className={style.icon} />
+                <Label className={style.labelIcon} />
               ) : (
-                <LabelOutlined className={style.icon} />
+                <LabelOutlined className={style.labelIcon} />
               )}
-              <ListItemText primary={label} className={style.text} />
+              <ListItemText primary={label} className={style.labelText} />
             </ListItem>
           ))}
+        </List>
+        <List component="span" disablePadding className={style.buttonsList}>
+          <ListItem className={style.buttonsListItem}>
+            <IconButton
+              className={style.iconButton}
+              onClick={() => setSelectedLabels(imageLabels)}
+              onMouseOver={() => setInfoOnHover("Select All labels")}
+              onMouseOut={() => setInfoOnHover("")}
+            >
+              <LibraryAddCheckOutlined />
+            </IconButton>
+
+            <IconButton
+              className={style.iconButton}
+              onClick={deselectAllLabels}
+              onMouseOver={() => setInfoOnHover("Deselect All labels")}
+              onMouseOut={() => setInfoOnHover("")}
+            >
+              <HighlightOffOutlined />
+            </IconButton>
+          </ListItem>
+          <ListItem className={style.infoOnHover}>{infoOnHover}</ListItem>
         </List>
       </AccordionDetails>
     </Accordion>


### PR DESCRIPTION
# Description

Adds:
- Double-click to select/deselect all labels but one (as in #31)
- Select/deselect all labels (buttons and hover info, as described in Josh's UI layout, see #38)

closes #31

# Dependency changes
No

# Testing
No

# Documentation
No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
