### PR TITLE
feat: Add save uploaded images callback

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-# .npmignore
-src
-examples
-.babelrc
-.gitignore
-webpack.config.js

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "gliff.ai CURATE",
   "repository": "git://github.com/gliff-ai/curate.git",
   "main": "dist/main.js",
-  "module": "dist/src/index.jsx", 
-  "types": "dist/src/index.d.ts", 
+  "module": "dist/src/index.tsx", 
+  "typings": "dist/src/index.d.ts", 
   "files": [
     "dist/*"
   ],
   "scripts": {
-    "build": "webpack --progress --config webpack.config.js",
+    "build": "webpack --progress --config webpack.build.js",
     "format": "npx --no-install prettier --write src/{**,.}/*.ts*",
     "prettier": "npx --no-install prettier -c src/{**,.}/*.ts*",
     "lint": "npm run lint:ts && npm run prettier",

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -40,7 +40,7 @@ const styles = (theme: Theme) => ({
 });
 
 interface Props extends WithStyles<typeof styles> {
-  metadata: Metadata;
+  metadata?: Metadata;
 }
 
 interface State {
@@ -58,7 +58,9 @@ class UserInterface extends Component<Props, State> {
 
     this.state = {
       metadata: this.addFieldSelectedToMetadata(this.props.metadata),
-      metadataKeys: this.getMetadataKeys(this.props.metadata[0]),
+      metadataKeys: this.props.metadata
+        ? this.getMetadataKeys(this.props.metadata[0])
+        : [],
       imageLabels: this.getImageLabels(this.props.metadata),
       expanded: "labels-filter-toolbox",
       selected: null,
@@ -70,6 +72,7 @@ class UserInterface extends Component<Props, State> {
   addFieldSelectedToMetadata = (metadata: Metadata): Metadata => {
     // Add field "selected" to metdata; this field is used to define which
     // metadata items are displayed on the dashboard.
+    if (!metadata) return [];
     metadata.forEach((mitem) => {
       mitem.selected = true;
     });
@@ -237,6 +240,7 @@ class UserInterface extends Component<Props, State> {
   };
 
   getImageLabels = (metadata: Metadata): string[] => {
+    if (!metadata) return [];
     const labels: Set<string> = new Set();
     metadata.forEach((mitem) => {
       (mitem.imageLabels as string[]).forEach((l) => labels.add(l));
@@ -278,9 +282,16 @@ class UserInterface extends Component<Props, State> {
           thumbnail,
           selected: true,
         };
-        this.setState((state) => ({
-          metadata: state.metadata.concat(newMetadata),
-        }));
+        this.setState((state) => {
+          const metaKeys =
+            state.metadataKeys.length === 0
+              ? this.getMetadataKeys(newMetadata)
+              : state.metadataKeys;
+          return {
+            metadata: state.metadata.concat(newMetadata),
+            metadataKeys: metaKeys,
+          };
+        });
       },
       (error) => {
         console.log(error);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -41,6 +41,10 @@ const styles = (theme: Theme) => ({
 
 interface Props extends WithStyles<typeof styles> {
   metadata?: Metadata;
+  saveImageCallback?: (
+    imageFileInfo: ImageFileInfo,
+    image: ImageBitmap[][]
+  ) => void;
 }
 
 interface State {
@@ -265,7 +269,7 @@ class UserInterface extends Component<Props, State> {
 
   addUploadedImage = (
     imageFileInfo: ImageFileInfo,
-    images: Array<Array<ImageBitmap>>
+    images: ImageBitmap[][]
   ) => {
     this.makeThumbnail(images).then(
       (thumbnail) => {
@@ -297,6 +301,10 @@ class UserInterface extends Component<Props, State> {
         console.log(error);
       }
     );
+    // Store uploaded image in etebase
+    if (this.props.saveImageCallback) {
+      this.props.saveImageCallback(imageFileInfo, images);
+    }
   };
 
   render = (): ReactNode => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "es2020",
     "sourceMap": true,
     "target": "es6",
-    "jsx": "react",
+    "jsx": "react-jsxdev",
     "allowJs": false,
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -14,7 +14,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "experimentalDecorators": true,
   },
   "include": [
     "typings/**/*",

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -4,6 +4,8 @@ module.exports = {
   entry: {
     main: "./src/index.tsx",
   },
+  mode: "development",
+  devtool: "source-map",
   output: {
     filename: "main.js",
     path: path.resolve(__dirname, "dist"),
@@ -37,7 +39,15 @@ module.exports = {
         use: {
           loader: "babel-loader",
           options: {
-            presets: ["@babel/preset-env", "@babel/react"],
+            presets: [
+              "@babel/preset-env",
+              [
+                "@babel/preset-react",
+                {
+                  runtime: "automatic", // defaults to classic
+                },
+              ],
+            ],
             plugins: ["@babel/proposal-class-properties"],
           },
         },


### PR DESCRIPTION
# Description
Adds:
- make prop `metadata` optional and change Curate so that it loads without props
- add callback for saving uploaded images as props

part 1 of gliff-ai/dominate#94

# Dependency changes
No

# Testing
No

# Documentation
No

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
