### PR TITLE
feat: add number to allowed metadata types

### DIFF
--- a/src/searchAndSort/interfaces.ts
+++ b/src/searchAndSort/interfaces.ts
@@ -1,7 +1,7 @@
 export type Metadata = Array<MetaItem>;
 
 export type MetaItem = {
-  [index: string]: string | string[] | ImageBitmap | boolean;
+  [index: string]: string | string[] | ImageBitmap | boolean | number;
 };
 
 export type Filter = {


### PR DESCRIPTION
Adds `number` to allowed metadata types. Makes life a lot easier.