### PR TITLE
feat: Select multiple thumbnails and delete

### DIFF
--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -9,9 +9,29 @@ export default function Tile(props: { mitem: MetaItem }): ReactElement {
       ref={(canvas) => {
         if (canvas) {
           // Keep this as it is initially null
-          const canvasContext = canvas.getContext("2d");
           if (props.mitem.thumbnail !== undefined) {
-            canvasContext.drawImage(props.mitem.thumbnail as ImageBitmap, 0, 0);
+            const canvasContext = canvas.getContext("2d");
+            canvasContext.clearRect(0, 0, canvas.width, canvas.height);
+            const image = props.mitem.thumbnail as ImageBitmap;
+
+            // Draw image fitting it to the canvas
+            const imageWidth = image.width;
+            const imageHeight = image.height;
+            const ratio = Math.min(
+              canvas.width / imageWidth,
+              canvas.height / imageHeight
+            );
+            canvasContext.drawImage(
+              image,
+              0,
+              0,
+              imageWidth,
+              imageHeight,
+              (canvas.width - imageWidth * ratio) / 2,
+              (canvas.height - imageHeight * ratio) / 2,
+              imageWidth * ratio,
+              imageHeight * ratio
+            );
           }
         }
       }}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -272,49 +272,34 @@ class UserInterface extends Component<Props, State> {
   getImageNames = (data: Metadata): string[] =>
     data.map((mitem: MetaItem) => mitem.imageName as string);
 
-  makeThumbnail = (image: Array<Array<ImageBitmap>>): Promise<ImageBitmap> => {
-    const canvas = document.createElement("canvas");
-    canvas.width = 128;
-    canvas.height = 128;
-    const ctx = canvas.getContext("2d");
-    ctx.drawImage(image[0][0], 0, 0, 128, 128);
-    return createImageBitmap(canvas);
-  };
-
   addUploadedImage = (
     imageFileInfo: ImageFileInfo,
     images: ImageBitmap[][]
   ) => {
-    this.makeThumbnail(images).then(
-      (thumbnail) => {
-        const today = new Date();
-        const newMetadata = {
-          imageName: imageFileInfo.fileName,
-          id: imageFileInfo.fileID,
-          dateCreated: today.toLocaleDateString("gb-EN"),
-          size: imageFileInfo.size.toString(),
-          dimensions: `${imageFileInfo.width} x ${imageFileInfo.height}`,
-          numberOfDimensions: images.length === 1 ? "2" : "3",
-          numberOfChannels: images[0].length.toString(),
-          imageLabels: [] as Array<string>,
-          thumbnail,
-          selected: true,
-        };
-        this.setState((state) => {
-          const metaKeys =
-            state.metadataKeys.length === 0
-              ? this.getMetadataKeys(newMetadata)
-              : state.metadataKeys;
-          return {
-            metadata: state.metadata.concat(newMetadata),
-            metadataKeys: metaKeys,
-          };
-        });
-      },
-      (error) => {
-        console.log(error);
-      }
-    );
+    const today = new Date();
+    const newMetadata = {
+      imageName: imageFileInfo.fileName,
+      id: imageFileInfo.fileID,
+      dateCreated: today.toLocaleDateString("gb-EN"),
+      size: imageFileInfo.size.toString(),
+      dimensions: `${imageFileInfo.width} x ${imageFileInfo.height}`,
+      numberOfDimensions: images.length === 1 ? "2" : "3",
+      numberOfChannels: images[0].length.toString(),
+      imageLabels: [] as Array<string>,
+      thumbnail: images[0][0],
+      selected: true,
+    };
+    this.setState((state) => {
+      const metaKeys =
+        state.metadataKeys.length === 0
+          ? this.getMetadataKeys(newMetadata)
+          : state.metadataKeys;
+      return {
+        metadata: state.metadata.concat(newMetadata),
+        metadataKeys: metaKeys,
+      };
+    });
+
     // Store uploaded image in etebase
     if (this.props.saveImageCallback) {
       this.props.saveImageCallback(imageFileInfo, images);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -345,6 +345,7 @@ class UserInterface extends Component<Props, State> {
     }
     return null;
   };
+
   updateLabels =
     (itemIndex: number) =>
     (newLabels: string[]): void => {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable  no-param-reassign */
-import React, { Component, ChangeEvent, ReactNode, KeyboardEvent } from "react";
+import React, {
+  Component,
+  ChangeEvent,
+  ReactNode,
+  KeyboardEvent,
+  MouseEvent,
+} from "react";
 import {
   AppBar,
   CssBaseline,
@@ -328,15 +334,14 @@ class UserInterface extends Component<Props, State> {
       };
     });
 
-    // TODO: add here callback for deleting images
+    // TODO: add dominated callback deleting images from store.
   };
 
-  getNextSelectedUid = (forward = true): number | null => {
+  getItemUidNextToLastSelected = (forward = true): number | null => {
     const inc = forward ? 1 : -1;
     let index: number;
     for (let i = 0; i < this.state.metadata.length; i += 1) {
       index = i + inc;
-      console.log(index);
       if (
         this.state.metadata[i].id ===
           this.state.selectedImagesUid.slice(-1).pop() &&
@@ -443,38 +448,56 @@ class UserInterface extends Component<Props, State> {
                   }}
                 >
                   <Button
-                    onClick={() => {
-                      this.setState({
-                        selectedImagesUid: [mitem.id as string],
-                      });
+                    onClick={(e: MouseEvent) => {
+                      const itemUid = mitem.id as string;
+
+                      if (e.metaKey) {
+                        // Select clicked item if unselected; deselect if already selected
+                        this.setState((state) => {
+                          if (state.selectedImagesUid.includes(itemUid)) {
+                            state.selectedImagesUid.splice(
+                              state.selectedImagesUid.indexOf(itemUid),
+                              1
+                            );
+                          } else {
+                            state.selectedImagesUid.push(itemUid);
+                          }
+                          return {
+                            selectedImagesUid: state.selectedImagesUid,
+                          };
+                        });
+                      } else {
+                        // Select only clicked item
+                        this.setState({ selectedImagesUid: [itemUid] });
+                      }
                     }}
                     onDoubleClick={this.handleMetaDrawerOpen(
                       mitem.id as string
                     )}
-                    onKeyUp={(event: KeyboardEvent) => {
+                    onKeyDown={(e: KeyboardEvent) => {
                       if (
-                        event.key === "ArrowLeft" ||
-                        event.key === "ArrowRight"
+                        e.shiftKey &&
+                        (e.key === "ArrowLeft" || e.key === "ArrowRight")
                       ) {
-                        const index = this.getNextSelectedUid(
-                          event.key === "ArrowRight"
+                        // Select consecutive items to the left or to the right of the clicked item
+                        const index = this.getItemUidNextToLastSelected(
+                          e.key === "ArrowRight"
                         );
                         if (index !== null) {
                           this.setState((state) => {
-                            console.log(index);
-                            console.log(state.metadata);
-                            const uid = state.metadata[index].id as string;
-                            if (state.selectedImagesUid.includes(uid)) {
+                            const itemUid = state.metadata[index].id as string;
+                            if (state.selectedImagesUid.includes(itemUid)) {
                               state.selectedImagesUid.pop();
                             } else {
-                              state.selectedImagesUid.push(uid);
+                              state.selectedImagesUid.push(itemUid);
                             }
                             return {
                               selectedImagesUid: state.selectedImagesUid,
                             };
                           });
                         }
-                      } else if (event.key === "Escape") {
+                      } else if (e.key === "Escape") {
+                        // Remove any selection
                         this.setState({ selectedImagesUid: [] });
                       }
                     }}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -451,7 +451,7 @@ class UserInterface extends Component<Props, State> {
                     onClick={(e: MouseEvent) => {
                       const itemUid = mitem.id as string;
 
-                      if (e.metaKey) {
+                      if (e.metaKey || e.ctrlKey) {
                         // Select clicked item if unselected; deselect if already selected
                         this.setState((state) => {
                           if (state.selectedImagesUid.includes(itemUid)) {


### PR DESCRIPTION
# Description

Adds:
- select multiple thumbnails
- delete selected thumbnails
- scale images so they fit inside the canvas

Notes: 
- single click on thumbnail to select a single image
- double-click to open metadata drawer
- command/ctrl  + click to select multiple non-consecutive images
- shift + arrow left/right to select multiple consecutive images
- shift + click to select all images between the two clicked images
- esc to deselect all 

closes #87 
closes #88

# Dependency changes
No

# Testing
No

# Documentation
No


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
