### PR TITLE
feat: add saveLabelsCallback, and use it

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -53,6 +53,7 @@ interface Props extends WithStyles<typeof styles> {
     imageFileInfo: ImageFileInfo,
     image: ImageBitmap[][]
   ) => void;
+  saveLabelsCallback?: (imageUid: string, newLabels: string[]) => void;
 }
 
 interface State {
@@ -393,6 +394,12 @@ class UserInterface extends Component<Props, State> {
     (newLabels: string[]): void => {
       this.setState((state) => {
         state.metadata[itemIndex].imageLabels = newLabels;
+        if (this.props.saveLabelsCallback) {
+          this.props.saveLabelsCallback(
+            state.metadata[itemIndex].id as string,
+            newLabels
+          );
+        }
         return {
           metadata: state.metadata,
           imageLabels: this.getImageLabels(state.metadata),


### PR DESCRIPTION
# Description

Adds a `saveLabelsCallback` prop, calls it from `updateLabels`.

closes #49 
(will need to merge dominate PR for this to work of course)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
