### PR TITLE
fix: name webpack files sensibly

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "dist/*"
   ],
   "scripts": {
-    "build": "webpack --progress --config webpack.config.js",
+    "build": "webpack --progress --config webpack.build.js",
     "format": "npx --no-install prettier --write src/{**,.}/*.ts*",
     "prettier": "npx --no-install prettier -c src/{**,.}/*.ts*",
     "lint": "npm run lint:ts && npm run prettier",
     "lint:ts": "npx eslint src/{**,.}/*.ts*",
-    "serve": "webpack serve --config webpack.config.js",
+    "serve": "webpack serve --config webpack.build.js",
     "test": "jest --coverage --passWithNoTests",
-    "prepublishOnly": "rm -r dist/; webpack --progress --config webpack.build.js"
+    "prepublishOnly": "rm -r dist/; webpack --progress --config webpack.package.js"
   },
   "license": "AGPL-3.0-only",
   "devDependencies": {

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -1,31 +1,13 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
 const path = require("path");
 
+const port = process.env.PORT || 3000;
+
 module.exports = {
-  entry: {
-    main: "./src/index.tsx",
-  },
+  entry: "./examples/src/index.tsx",
   mode: "development",
-  devtool: "source-map",
-  output: {
-    filename: "main.js",
-    path: path.resolve(__dirname, "dist"),
-    libraryTarget: "commonjs",
-  },
-  externals: {
-    // Don't bundle react or react-dom
-    react: {
-      commonjs: "react",
-      commonjs2: "react",
-      amd: "React",
-      root: "React",
-    },
-    "react-dom": {
-      commonjs: "react-dom",
-      commonjs2: "react-dom",
-      amd: "ReactDOM",
-      root: "ReactDOM",
-    },
-  },
+  devtool: "eval-source-map",
   module: {
     rules: [
       {
@@ -33,21 +15,14 @@ module.exports = {
         use: "ts-loader",
         exclude: /node_modules/,
       },
+
       {
         test: /\.m?js$/,
         exclude: /(node_modules|bower_components)/,
         use: {
           loader: "babel-loader",
           options: {
-            presets: [
-              "@babel/preset-env",
-              [
-                "@babel/preset-react",
-                {
-                  runtime: "automatic", // defaults to classic
-                },
-              ],
-            ],
+            presets: ["@babel/preset-env", "@babel/react"],
             plugins: ["@babel/proposal-class-properties"],
           },
         },
@@ -56,7 +31,7 @@ module.exports = {
         test: /\.(s*)css$/,
         use: ["style-loader", "css-loader", "sass-loader"],
       },
-        {
+      {
         test: /\.(jpe?g|png|gif|woff|woff2|eot|ttf|svg)(\?[a-z0-9=.]+)?$/,
         use: {
           loader: "url-loader",
@@ -73,5 +48,28 @@ module.exports = {
     alias: {
       "@": path.resolve(__dirname, "src"),
     },
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: "examples/index.html",
+    }),
+    new CopyPlugin({
+      patterns: [
+        {
+          from: "examples/samples",
+          to: "samples",
+        },
+        {
+          from: "examples/metadata.json",
+          to: "metadata.json",
+        },
+      ],
+    }),
+  ],
+  devServer: {
+    host: "localhost",
+    port,
+    historyApiFallback: true,
+    open: true,
   },
 };

--- a/webpack.package.js
+++ b/webpack.package.js
@@ -1,14 +1,30 @@
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const CopyPlugin = require("copy-webpack-plugin");
 const path = require("path");
 
-const port = process.env.PORT || 3000;
-
-
 module.exports = {
-  entry: "./examples/src/index.tsx",
-  mode: "development",
+  entry: {
+    main: "./src/index.tsx",
+  },
   devtool: "source-map",
+  output: {
+    filename: "main.js",
+    path: path.resolve(__dirname, "dist"),
+    libraryTarget: "commonjs",
+  },
+  externals: {
+    // Don't bundle react or react-dom
+    react: {
+      commonjs: "react",
+      commonjs2: "react",
+      amd: "React",
+      root: "React",
+    },
+    "react-dom": {
+      commonjs: "react-dom",
+      commonjs2: "react-dom",
+      amd: "ReactDOM",
+      root: "ReactDOM",
+    },
+  },
   module: {
     rules: [
       {
@@ -16,14 +32,21 @@ module.exports = {
         use: "ts-loader",
         exclude: /node_modules/,
       },
-
       {
         test: /\.m?js$/,
         exclude: /(node_modules|bower_components)/,
         use: {
           loader: "babel-loader",
           options: {
-            presets: ["@babel/preset-env", "@babel/react"],
+            presets: [
+              "@babel/preset-env",
+              [
+                "@babel/preset-react",
+                {
+                  runtime: "automatic", // defaults to classic
+                },
+              ],
+            ],
             plugins: ["@babel/proposal-class-properties"],
           },
         },
@@ -32,7 +55,7 @@ module.exports = {
         test: /\.(s*)css$/,
         use: ["style-loader", "css-loader", "sass-loader"],
       },
-        {
+      {
         test: /\.(jpe?g|png|gif|woff|woff2|eot|ttf|svg)(\?[a-z0-9=.]+)?$/,
         use: {
           loader: "url-loader",
@@ -49,28 +72,5 @@ module.exports = {
     alias: {
       "@": path.resolve(__dirname, "src"),
     },
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: "examples/index.html",
-    }),
-    new CopyPlugin({
-      patterns: [
-        {
-          from: "examples/samples",
-          to: "samples",
-        },
-        {
-          from: "examples/metadata.json",
-          to: "metadata.json",
-        },
-      ],
-    }),
-  ],
-  devServer: {
-    host: "localhost",
-    port,
-    historyApiFallback: true,
-    open: true,
   },
 };


### PR DESCRIPTION
# Description

Rename the webpack configs to clearly differentiate between building the example and packaging for npm.

Build uses a very verbose sourcemap and dev mode as it's published to staging.curate.gliff.app for our use only or served locally

Package still creates a source map and links to it (as it's open source, revealing the code isn't an issue), but also builds in prod mode so the code should be much smaller!