### PR TITLE
Wrap Image Names etc

### DIFF
--- a/examples/metadata.json
+++ b/examples/metadata.json
@@ -1,6 +1,6 @@
 [
     {
-        "imageName": "sample0.png",
+        "imageName": "big_long_name_sample_sample0.png",
         "size": "1260 bytes",
         "dateCreated": "Apr 28 2021",
         "dimensions": "120 x 140",
@@ -159,5 +159,5 @@
         "imageLabels": ["label2", "label7"],
         "fileMetaVersion": "1.0.0"
     }
-    
+
 ]

--- a/src/MetadataDrawer.tsx
+++ b/src/MetadataDrawer.tsx
@@ -149,11 +149,15 @@ export default function MetadataDrawer(props: Props): ReactElement {
                   <ListItemText
                     primaryTypographyProps={{ variant: "h6" }}
                     className={classes.metaKey}
+                    title={metadataNameMap[key]}
                   >
                     {metadataNameMap[key]}:
                   </ListItemText>
 
-                  <ListItemText className={classes.metaValue}>
+                  <ListItemText
+                    className={classes.metaValue}
+                    title={props.metadata[key] as string}
+                  >
                     {key === "imageLabels"
                       ? (props.metadata[key] as string[]).join(", ")
                       : props.metadata[key].toString()}

--- a/src/MetadataDrawer.tsx
+++ b/src/MetadataDrawer.tsx
@@ -56,10 +56,24 @@ const useStyles = makeStyles({
   card: {
     backgroundColor: theme.palette.primary.light,
   },
-  metadata: {
-    fontWeight: 500,
-  },
   svgSmall: { width: "12px", height: "100%" },
+  metaKey: {
+    width: "100px",
+    "& > span": {
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    },
+  },
+  metaValue: {
+    width: "180px",
+    "& > span": {
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    },
+  },
+  metaList: {},
 });
 
 export const metadataNameMap: MetadataNameMap = {
@@ -67,8 +81,8 @@ export const metadataNameMap: MetadataNameMap = {
   size: "Size",
   dateCreated: "Created",
   dimensions: "Dimensions",
-  numberOfDimensions: "Number Of Dimensions",
-  numberOfChannels: "Number Of Channels",
+  numberOfDimensions: "# Dimensions",
+  numberOfChannels: "# Channels",
   imageLabels: "Labels",
 };
 
@@ -131,13 +145,15 @@ export default function MetadataDrawer(props: Props): ReactElement {
             {Object.keys(props.metadata)
               .filter((key) => Object.keys(metadataNameMap).includes(key))
               .map((key) => (
-                <ListItem key={key}>
-                  <ListItemText>
-                    <Typography
-                      className={classes.metadata}
-                    >{`${metadataNameMap[key]}:`}</Typography>
+                <ListItem key={key} className={classes.metaList}>
+                  <ListItemText
+                    primaryTypographyProps={{ variant: "h6" }}
+                    className={classes.metaKey}
+                  >
+                    {metadataNameMap[key]}:
                   </ListItemText>
-                  <ListItemText>
+
+                  <ListItemText className={classes.metaValue}>
                     {key === "imageLabels"
                       ? (props.metadata[key] as string[]).join(", ")
                       : props.metadata[key].toString()}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -18,6 +18,10 @@ const theme: Theme = createMuiTheme({
   },
   typography: {
     fontFamily: "Roboto",
+    h6: {
+      fontWeight: 500,
+      fontSize: "0.875rem", // Same as body2
+    },
   },
 
   shape: {


### PR DESCRIPTION
Truncate metadata if it's too long

FIx #98 

![image](https://user-images.githubusercontent.com/3502798/124264080-f4ad3200-db2b-11eb-821e-a668b21a1d65.png)

When we refactor into a proper theme, we can have a "truncate" class which will make life better
