### PR TITLE
feat: Full-screen spinner

### DIFF
--- a/src/decorators/index.tsx
+++ b/src/decorators/index.tsx
@@ -1,1 +1,1 @@
-export { logTaskExecution } from "./progress";
+export { logTaskExecution, pageLoading } from "./progress";

--- a/src/decorators/progress.tsx
+++ b/src/decorators/progress.tsx
@@ -38,4 +38,26 @@ function logTaskExecution(taskDescription: string) {
   };
 }
 
-export { logTaskExecution };
+function pageLoading(
+  target: UI,
+  propertyKey: string,
+  descriptor: Descriptor
+): void {
+  const targetMethod = descriptor.value;
+
+  descriptor.value = async function decoratorWrapper(...args) {
+    const setIsLoading = (this as UI).props?.setIsLoading;
+
+    if (typeof setIsLoading === "function") {
+      setIsLoading(true);
+    }
+
+    const result: unknown = await targetMethod.apply(this, args);
+
+    if (typeof setIsLoading === "function") {
+      setIsLoading(false);
+    }
+  };
+}
+
+export { logTaskExecution, pageLoading };

--- a/src/decorators/progress.tsx
+++ b/src/decorators/progress.tsx
@@ -48,10 +48,6 @@ function pageLoading(
   descriptor.value = async function decoratorWrapper(...args) {
     const setIsLoading = (this as UI).props?.setIsLoading;
 
-    if (typeof setIsLoading === "function") {
-      setIsLoading(true);
-    }
-
     const result: unknown = await targetMethod.apply(this, args);
 
     if (typeof setIsLoading === "function") {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -28,7 +28,7 @@ import { svgSrc } from "@/helpers";
 import TooltipButton from "@/components/TooltipButton";
 import { LabelsPopover } from "@/components/LabelsPopover";
 import { SortPopover } from "@/sort/SortPopover";
-import { logTaskExecution } from "@/decorators";
+import { logTaskExecution, pageLoading } from "@/decorators";
 import MetadataDrawer from "./MetadataDrawer";
 import SizeThumbnails, { thumbnailSizes } from "./components/SizeThumbnails";
 import { Metadata, MetaItem, Filter } from "./searchAndSort/interfaces";
@@ -121,6 +121,7 @@ interface Props extends WithStyles<typeof styles> {
   deleteImagesCallback?: (imageUids: string[]) => void;
   annotateCallback?: (id: string) => void;
   setTask?: (task: { isLoading: boolean; description?: string }) => void;
+  setIsLoading?: (isLoading: boolean) => void;
 }
 
 interface State {
@@ -162,6 +163,9 @@ class UserInterface extends Component<Props, State> {
     /* eslint-disable @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-assignment */
     this.addUploadedImage = this.addUploadedImage.bind(this);
   }
+
+  @pageLoading
+  componentDidMount() {}
 
   /* eslint-disable react/no-did-update-set-state */
   // TODO: remove state.metadata, just use props.metadata


### PR DESCRIPTION
# Description
Add decorator to stop rendering a loading spinner as soon as curate mounts (works only when curate is loaded onto dominate).

gliff-ai/roadmap/issues/54, full-screen spinner for page load.

# Dependency changes
No

# Testing
No

# Documentation
No

# Migrations (if applicable)

Have any database migrations been committed as part of this pull request?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
