### PR TITLE
fix: Hardcoded list of metadata keys

### DIFF
--- a/src/MetadataDrawer.tsx
+++ b/src/MetadataDrawer.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { ReactElement, useState, useEffect } from "react";
 import {
   ListItem,
   Typography,
@@ -9,12 +9,16 @@ import {
   Card,
   Avatar,
   Box,
+  makeStyles,
 } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
 import { theme, HtmlTooltip } from "@gliff-ai/style";
 import SVG from "react-inlinesvg";
 import { MetaItem } from "@/searchAndSort/interfaces";
 import { imgSrc } from "./helpers";
+import {
+  getLabelsFromKeys,
+  MetadataLabel,
+} from "@/searchAndSort/SearchAndSortBar";
 
 type MetadataNameMap = { [index: string]: string };
 
@@ -111,6 +115,16 @@ interface Props {
 export default function MetadataDrawer(props: Props): ReactElement {
   const classes = useStyles();
   const [hover, sethover] = useState(false);
+  const [metaKeys, setMetaKeys] = useState<MetadataLabel[]>([]);
+
+  useEffect(() => {
+    setMetaKeys(
+      Object.keys(props.metadata).reduce(
+        getLabelsFromKeys,
+        [] as MetadataLabel[]
+      )
+    );
+  }, [props.metadata]);
 
   return (
     <>
@@ -159,35 +173,33 @@ export default function MetadataDrawer(props: Props): ReactElement {
         </Paper>
         <Paper elevation={0} square>
           <List>
-            {Object.keys(props.metadata)
-              .filter((key) => Object.keys(metadataNameMap).includes(key))
-              .map((key) => (
-                <ListItem key={key} className={classes.metaListItem}>
-                  <ListItemText
-                    primaryTypographyProps={{ variant: "h6" }}
-                    className={classes.metaKey}
-                    title={metadataNameMap[key]}
-                    primary={`${metadataNameMap[key]}:`}
-                    classes={{
-                      primary: classes.metaKey,
-                      root: classes.metaRoot,
-                    }}
-                  />
-                  <ListItemText
-                    className={classes.metaValue}
-                    title={props.metadata[key] as string}
-                    primary={
-                      key === "imageLabels"
-                        ? (props.metadata[key] as string[]).join(", ")
-                        : props.metadata[key].toString()
-                    }
-                    classes={{
-                      primary: classes.metaValue,
-                      root: classes.metaRoot,
-                    }}
-                  />
-                </ListItem>
-              ))}
+            {metaKeys.map(({ key }) => (
+              <ListItem key={key} className={classes.metaListItem}>
+                <ListItemText
+                  primaryTypographyProps={{ variant: "h6" }}
+                  className={classes.metaKey}
+                  title={metadataNameMap[key] || key}
+                  primary={`${metadataNameMap[key] || key}:`}
+                  classes={{
+                    primary: classes.metaKey,
+                    root: classes.metaRoot,
+                  }}
+                />
+                <ListItemText
+                  className={classes.metaValue}
+                  title={props.metadata[key] as string}
+                  primary={
+                    key === "imageLabels"
+                      ? (props.metadata[key] as string[]).join(", ")
+                      : props.metadata[key].toString()
+                  }
+                  classes={{
+                    primary: classes.metaValue,
+                    root: classes.metaRoot,
+                  }}
+                />
+              </ListItem>
+            ))}
           </List>
         </Paper>
       </Card>

--- a/src/searchAndSort/SearchAndSortBar.tsx
+++ b/src/searchAndSort/SearchAndSortBar.tsx
@@ -60,7 +60,10 @@ export const getLabelsFromKeys = (
   key: string
 ): MetadataLabel[] => {
   // Just an example of how to exclude metadata from the list if we need
-  if (["fileMetaVersion", "id", "thumbnail"].includes(key)) return acc;
+  if (
+    ["fileMetaVersion", "id", "thumbnail", "selected", "newGroup"].includes(key)
+  )
+    return acc;
 
   const label = metadataNameMap[key] || key;
   acc.push({


### PR DESCRIPTION
## Description
At present all metadata keys not listed in`metadataNameMap` are excluded from the metadata section. 
I've changed `MetadataDrawer.tsx` so that all sensible matadata keys are displayed in the drawer, even if they miss an extended name.

## Dependency changes
No

## Testing
No

## Documentation
No

## Migrations (if applicable)
No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
