### PR TITLE
feat: Add plugins prop

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -132,6 +132,8 @@ interface Props extends WithStyles<typeof styles> {
   trustedServiceButtonToolbar?:
     | ((imageUid?: string, enabled?: boolean) => ReactNode)
     | null;
+
+  plugins?: JSX.Element | null;
 }
 
 interface State {
@@ -153,6 +155,7 @@ class UserInterface extends Component<Props, State> {
   static defaultProps = {
     showAppBar: true,
     trustedServiceButtonToolbar: null,
+    plugins: null,
   } as Pick<Props, "showAppBar">;
 
   constructor(props: Props) {
@@ -661,6 +664,7 @@ class UserInterface extends Component<Props, State> {
                       display: "flex",
                       bottom: "18px",
                       position: "fixed",
+                      zIndex: 1,
                     }}
                   >
                     <Card className={classes.bottomLeftButtons}>
@@ -700,6 +704,11 @@ class UserInterface extends Component<Props, State> {
                           this.state.openImageUid,
                           Boolean(this.state.openImageUid !== null)
                         )}
+                      </Card>
+                    )}
+                    {this.props.plugins && (
+                      <Card className={classes.bottomLeftButtons}>
+                        {this.props.plugins}
                       </Card>
                     )}
                   </div>


### PR DESCRIPTION
## Description
Add `plugins` prop to pass down to CURATE a button toolbar with all the plugins. Works only when CURATE is loaded onto DOMINATE.

## Dependency changes
No

## Testing
No

## Documentation
No


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
