### PR TITLE
fix: Sort and search don't work with missing metadata keys

### DIFF
--- a/src/MetadataDrawer.tsx
+++ b/src/MetadataDrawer.tsx
@@ -126,6 +126,9 @@ export default function MetadataDrawer(props: Props): ReactElement {
     );
   }, [props.metadata]);
 
+  const hasKey = (mitem: MetaItem, key: string): boolean =>
+    key in mitem && mitem[key] !== null;
+
   return (
     <>
       <Card className={classes.card}>
@@ -173,33 +176,35 @@ export default function MetadataDrawer(props: Props): ReactElement {
         </Paper>
         <Paper elevation={0} square>
           <List>
-            {metaKeys.map(({ key }) => (
-              <ListItem key={key} className={classes.metaListItem}>
-                <ListItemText
-                  primaryTypographyProps={{ variant: "h6" }}
-                  className={classes.metaKey}
-                  title={metadataNameMap[key] || key}
-                  primary={`${metadataNameMap[key] || key}:`}
-                  classes={{
-                    primary: classes.metaKey,
-                    root: classes.metaRoot,
-                  }}
-                />
-                <ListItemText
-                  className={classes.metaValue}
-                  title={props.metadata[key] as string}
-                  primary={
-                    key === "imageLabels"
-                      ? (props.metadata[key] as string[]).join(", ")
-                      : props.metadata[key].toString()
-                  }
-                  classes={{
-                    primary: classes.metaValue,
-                    root: classes.metaRoot,
-                  }}
-                />
-              </ListItem>
-            ))}
+            {metaKeys.map(({ key }) =>
+              hasKey(props.metadata, key) ? (
+                <ListItem key={key} className={classes.metaListItem}>
+                  <ListItemText
+                    primaryTypographyProps={{ variant: "h6" }}
+                    className={classes.metaKey}
+                    title={metadataNameMap[key] || key}
+                    primary={`${metadataNameMap[key] || key}:`}
+                    classes={{
+                      primary: classes.metaKey,
+                      root: classes.metaRoot,
+                    }}
+                  />
+                  <ListItemText
+                    className={classes.metaValue}
+                    title={props.metadata[key] as string}
+                    primary={
+                      key === "imageLabels"
+                        ? (props.metadata[key] as string[]).join(", ")
+                        : props.metadata[key].toString()
+                    }
+                    classes={{
+                      primary: classes.metaValue,
+                      root: classes.metaRoot,
+                    }}
+                  />
+                </ListItem>
+              ) : null
+            )}
           </List>
         </Paper>
       </Card>

--- a/src/searchAndSort/SearchAndSortBar.tsx
+++ b/src/searchAndSort/SearchAndSortBar.tsx
@@ -88,7 +88,7 @@ export default function SearchAndSortBar({
     if (!inputKey?.key || !metadataKeys.includes(inputKey.key)) return;
     const options: Set<string> = new Set();
     metadata.forEach((mitem: MetaItem) => {
-      if (mitem.selected) {
+      if (mitem.selected && mitem[inputKey.key] !== undefined) {
         const value = mitem[inputKey.key];
         if (Array.isArray(value)) {
           value.forEach((v) => options.add(v));

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -349,9 +349,10 @@ class UserInterface extends Component<Props, State> {
 
     if (key === "") return; // for some reason this function is being called on startup with an empty key
 
+    // Number.MAX_VALUE added to handle missing values
     function compare(
-      a: string | Date | number,
-      b: string | Date | number,
+      a: string | Date | number = Number.MAX_VALUE,
+      b: string | Date | number = Number.MAX_VALUE,
       sort: string
     ): number {
       if (a < b) {
@@ -365,6 +366,7 @@ class UserInterface extends Component<Props, State> {
 
     this.setState((prevState) => {
       const isKeyDate = key?.toLowerCase().includes("date");
+
       if (isKeyDate) {
         // Sort by date
         prevState.metadata.sort((a: MetaItem, b: MetaItem): number =>
@@ -382,8 +384,8 @@ class UserInterface extends Component<Props, State> {
         // Sort by any string
         prevState.metadata.sort((a: MetaItem, b: MetaItem): number =>
           compare(
-            (a[key] as string).toLowerCase(),
-            (b[key] as string).toLowerCase(),
+            (a[key] as string)?.toLowerCase(),
+            (b[key] as string)?.toLowerCase(),
             sortOrder
           )
         );
@@ -409,7 +411,8 @@ class UserInterface extends Component<Props, State> {
     this.setState(({ metadata }) => {
       metadata.forEach((mitem) => {
         if (!mitem.selected) return;
-        const value = mitem[key] as string;
+        // Number.MAX_VALUE added to handle missing values
+        const value = (mitem[key] as string) || Number.MAX_VALUE;
         if (!prevValue || areValuesEqual(value, prevValue)) {
           mitem.newGroup = true;
         } else {


### PR DESCRIPTION
## Description
Image items can differ in their metadata content, so sort and search should work with missing metadata key-value pairs.

How missing values are handled:
Metadata drawer: not displayed in the drawer.
Sort: replaced with a high number.
Search: excluded.

## Dependency changes
No

## Testing
No

## Documentation
No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
