### PR TITLE
fix: don't clear tiles state on delete when store present

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -509,19 +509,23 @@ class UserInterface extends Component<Props, State> {
 
   deleteSelectedImages = (): void => {
     if (!this.state.selectedImagesUid) return;
-    this.setState((state) => {
-      const metadata: Metadata = state.metadata.filter(
-        (mitem) => !state.selectedImagesUid.includes(mitem.id as string)
-      );
 
-      this.props.deleteImagesCallback?.(state.selectedImagesUid);
+    this.props.deleteImagesCallback?.(this.state.selectedImagesUid);
 
-      return {
-        selectedImagesUid: [],
-        metadata,
-        imageLabels: this.getImageLabels(metadata),
-      };
-    });
+    if (!this.props.deleteImagesCallback) {
+      // running standalone, so remove images here and now rather than waiting for store to update:
+      this.setState((state) => {
+        const metadata: Metadata = state.metadata.filter(
+          (mitem) => !state.selectedImagesUid.includes(mitem.id as string)
+        );
+
+        return {
+          selectedImagesUid: [],
+          metadata,
+          imageLabels: this.getImageLabels(metadata),
+        };
+      });
+    }
   };
 
   getItemUidNextToLastSelected = (forward = true): number | null => {


### PR DESCRIPTION
## Description

We were directly clearing the tiles (`metadata`) state as soon as the user clicks delete. This is bad because the new confirmation dialog is implemented in DOMINATE, so CURATE can't know how the user responds and currently clears the tiles immediately before the user responds. But it's unnecessary when STORE is present anyway because the new state will be passed in once STORE updates. It's also better that the user doesn't see the images disappear until the deletion process completes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
