### PR TITLE
data-private tag on Tile elements

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -980,6 +980,7 @@ class UserInterface extends Component<Props, State> {
                                 mitem={mitem}
                                 width={this.state.thumbnailWidth}
                                 height={this.state.thumbnailHeight}
+                                data-private
                               />
                             </Button>
                             <LabelsPopover


### PR DESCRIPTION
## Description

This should make thumbnails invisible in logrocket.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
