### PR TITLE
build: fix history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^4.19.0",
         "@typescript-eslint/parser": "^4.18.0",
         "eslint": "^7.25.0",
-        "history": "^5.0.1",
+        "history": "==5.0.1",
         "jest": "^27.0.3",
         "prettier": "=2.3.0",
         "react": "^17.0.0",
@@ -47,7 +47,7 @@
         "@material-ui/core": "^4.11.3",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.58",
-        "history": "^5.0.1",
+        "history": "==5.0.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.18.0",
     "eslint": "^7.25.0",
-    "history": "^5.0.1",
+    "history": "==5.0.1",
     "jest": "^27.0.3",
     "prettier": "=2.3.0",
     "react": "^17.0.0",
@@ -52,7 +52,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
-    "history": "^5.0.1",
+    "history": "==5.0.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.1"
   },


### PR DESCRIPTION
as it says on the tin - needed because of react-router-dom eslewhere