### PR TITLE
test: Filter metadata

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,33 +1,39 @@
-import { Metadata } from "@/interfaces";
-import { sortMetadata } from "./helpers";
+import { Metadata, Filter } from "@/interfaces";
+import { sortMetadata, filterMetadata } from "./helpers";
 
 const metadata: Metadata = [
-  { string: "through", date: "01-26-1920", number: 12 },
+  {
+    string: "through",
+    date: "01-26-1920",
+    number: 12,
+    arrayOfString: ["perhaps"],
+  },
   { string: "soil", date: "02-15-2001" },
-  { date: "02-26-2001", number: 4.3 },
+  { date: "02-26-2001", number: 4.3, arrayOfString: ["pertain"] },
   { string: "science", date: "08-12-2030", number: 0.5 },
   { string: "perhaps", number: -1 },
-];
-
-// data type | expected result: metadata values in ascending order
-const testValues: [string, any[]][] = [
-  ["number", [-1, 0.5, 4.3, 12]],
-  ["string", ["perhaps", "science", "soil", "through"]],
-  ["date", ["01-26-1920", "02-15-2001", "02-26-2001", "08-12-2030"]],
+  { number: 12 },
 ];
 
 function cloneMetadata() {
-  return metadata.map((mitem) => ({ ...mitem }));
+  return metadata.map((mitem) => ({ ...mitem, selected: true }));
 }
 
 describe("sort metadata with missing values", () => {
-  test.each(testValues)(
+  // data type | expected result: metadata values in ascending order
+  const testSample: [string, any[]][] = [
+    ["number", [-1, 0.5, 4.3, 12, 12]],
+    ["string", ["perhaps", "science", "soil", "through"]],
+    ["date", ["01-26-1920", "02-15-2001", "02-26-2001", "08-12-2030"]],
+  ];
+
+  test.each(testSample)(
     `sort values of type %s`,
     (key: string, output: any[]) => {
       const metadataAsc = sortMetadata(cloneMetadata(), key);
       const metadataDes = sortMetadata(cloneMetadata(), key, false);
-      const arrayUndefined = Array.of(
-        metadata.filter((mitem) => key in Object.keys(mitem)).length
+      const arrayUndefined = Array.from(
+        metadata.filter((mitem) => !Object.keys(mitem).includes(key))
       ).fill(undefined);
 
       expect(metadataAsc.map((mitem) => mitem[key])).toEqual(
@@ -38,5 +44,63 @@ describe("sort metadata with missing values", () => {
         output.concat(arrayUndefined)
       );
     }
+  );
+});
+
+const testFilter = (filters: Filter[], outcome: Metadata): void => {
+  const newMetadata = filterMetadata(cloneMetadata(), filters);
+  expect(
+    newMetadata
+      .filter(({ selected }) => selected)
+      .map(({ selected, ...rest }) => rest)
+  ).toEqual(outcome);
+};
+
+describe("filter metadata", () => {
+  test.each([
+    {
+      filter: { key: "string", value: "science" },
+      outcome: [{ string: "science", date: "08-12-2030", number: 0.5 }],
+    },
+    {
+      filter: { key: "number", value: "12" },
+      outcome: [
+        {
+          string: "through",
+          date: "01-26-1920",
+          number: 12,
+          arrayOfString: ["perhaps"],
+        },
+        { number: 12 },
+      ],
+    },
+    {
+      filter: { key: "date", value: "08-12-2030" },
+      outcome: [{ string: "science", date: "08-12-2030", number: 0.5 }],
+    },
+    {
+      filter: { key: "arrayOfString", value: "per" },
+      outcome: [
+        {
+          string: "through",
+          date: "01-26-1920",
+          number: 12,
+          arrayOfString: ["perhaps"],
+        },
+        { date: "02-26-2001", number: 4.3, arrayOfString: ["pertain"] },
+      ],
+    },
+  ])("filter by $filter", ({ filter, outcome }) =>
+    testFilter([filter], outcome)
+  );
+
+  test.each([
+    {
+      filter1: { key: "string", value: "soil" },
+      filter2: { key: "number", value: "-1" },
+      outcome: [],
+    },
+  ])("filter by $filter1 AND $filter2", ({ filter1, filter2, outcome }) =>
+    testFilter([filter1, filter2], outcome)
   );
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Metadata, MetaItem } from "./interfaces";
+import { Metadata, MetaItem, Filter } from "./interfaces";
 
 function kCombinations(set: any[], k: number): any[][] {
   if (k > set.length || k <= 0) {
@@ -103,4 +103,33 @@ function sortMetadata(
   }
 }
 
-export { kCombinations, shuffle, sortMetadata };
+function filterMetadata(metadata: Metadata, activeFilters: Filter[]): Metadata {
+  if (activeFilters.length > 0) {
+    metadata.forEach((mitem) => {
+      activeFilters.forEach((filter, fi) => {
+        const value = mitem[filter.key];
+
+        // current filter selection
+        const currentSel = Number(
+          Array.isArray(value)
+            ? value.some((v) => v.includes(filter.value))
+            : String(value).includes(filter.value)
+        );
+
+        // selection for all filters up to current
+        const prevSel = fi === 0 ? 1 : Number(mitem.selected);
+
+        // update 'selected' field
+        mitem.selected = Boolean(prevSel * currentSel);
+      });
+    });
+  } else {
+    // all items selected
+    metadata.forEach((mitem) => {
+      mitem.selected = true;
+    });
+  }
+  return metadata;
+}
+
+export { kCombinations, shuffle, sortMetadata, filterMetadata };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Metadata, MetaItem, Filter } from "./interfaces";
+import { Metadata, MetaItem, Filter } from "@/interfaces";
 
 function kCombinations(set: any[], k: number): any[][] {
   if (k > set.length || k <= 0) {
@@ -105,7 +105,7 @@ function sortMetadata(
 
 function filterMetadata(metadata: Metadata, activeFilters: Filter[]): Metadata {
   if (activeFilters.length > 0) {
-    metadata.forEach((mitem) => {
+    metadata.forEach((mitem: MetaItem) => {
       activeFilters.forEach((filter, fi) => {
         const value = mitem[filter.key];
 
@@ -125,7 +125,7 @@ function filterMetadata(metadata: Metadata, activeFilters: Filter[]): Metadata {
     });
   } else {
     // all items selected
-    metadata.forEach((mitem) => {
+    metadata.forEach((mitem: MetaItem) => {
       mitem.selected = true;
     });
   }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -45,7 +45,7 @@ import { logTaskExecution, pageLoading } from "@/decorators";
 import MetadataDrawer from "./MetadataDrawer";
 import { Metadata, MetaItem, Filter } from "./interfaces";
 import { SearchBar, LabelsFilterAccordion, SearchFilterCard } from "@/search";
-import { sortMetadata } from "@/helpers";
+import { sortMetadata, filterMetadata } from "@/helpers";
 
 const styles = () => ({
   appBar: {
@@ -275,32 +275,9 @@ class UserInterface extends Component<Props, State> {
 
   applySearchFiltersToMetadata = (): void => {
     this.setState(({ metadata, activeFilters }) => {
-      if (activeFilters.length > 0) {
-        metadata.forEach((mitem) => {
-          activeFilters.forEach((filter, fi) => {
-            const value = mitem[filter.key];
+      const newMetadata = filterMetadata(metadata, activeFilters);
 
-            // Current filter selection
-            const currentSel = Number(
-              Array.isArray(value)
-                ? value.some((v) => v.includes(filter.value))
-                : String(value).includes(filter.value)
-            );
-
-            // Selection for all filter up to current
-            const prevSel = fi === 0 ? 1 : Number(mitem.selected);
-
-            // Update value for selected
-            mitem.selected = Boolean(prevSel * currentSel);
-          });
-        });
-      } else {
-        metadata.forEach((mitem) => {
-          mitem.selected = true;
-        });
-      }
-
-      return { metadata };
+      return newMetadata ? { metadata } : undefined;
     });
 
     if (this.state.isGrouped) {


### PR DESCRIPTION
## Description
- move method for filtering the metadata out of `ui.tsx`, so as to facilitate unit testing
- add unit test for `filterMetadata` function

## Dependency changes
no

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
