### PR TITLE
feat: nicer datatable

### DIFF
--- a/src/TableView.tsx
+++ b/src/TableView.tsx
@@ -1,0 +1,123 @@
+import { ReactElement, useState } from "react";
+import type { GridSelectionModel } from "@mui/x-data-grid";
+import {
+  DataGrid,
+  Chip,
+  Box,
+  Typography,
+  GridRenderCellParams,
+  GridColDef,
+  HtmlTooltip,
+} from "@gliff-ai/style";
+import { Metadata, MetaItem } from "@/interfaces";
+
+interface Props {
+  metadata: Metadata;
+}
+
+const defaultColumns = [
+  {
+    headerName: "Image Name",
+    field: "imageName",
+    width: 150,
+    editable: false,
+    sortable: false,
+  },
+  {
+    headerName: "Annotation Progress",
+    field: "annotationProgress",
+    width: 250,
+    editable: false,
+    sortable: false,
+  },
+  {
+    headerName: "Assignees",
+    field: "assignees",
+    width: 300,
+    editable: false,
+    sortable: false,
+  },
+  {
+    headerName: "Labels",
+    field: "labels",
+    width: 250,
+    editable: false,
+    sortable: false,
+    renderCell: (params: GridRenderCellParams<unknown, MetaItem>) => {
+      const { imageLabels = [] } = params.row;
+      const chipsLimit = 2;
+      const chipsContent: string[] = imageLabels.slice(0, chipsLimit);
+      const moreLabelsCount = imageLabels.length - chipsLimit;
+      const showPlaceholder =
+        moreLabelsCount > 0 ? (
+          <HtmlTooltip title={imageLabels.join(", ")} placement="bottom">
+            <Typography>+ {moreLabelsCount} more</Typography>
+          </HtmlTooltip>
+        ) : null;
+      const chips = chipsContent.map((imageLabel: string) => (
+        <Chip label={imageLabel} key={imageLabel} variant="outlined" />
+      ));
+      return [chips, showPlaceholder];
+    },
+  },
+
+  {
+    headerName: "Pixels",
+    field: "dimensions",
+    width: 150,
+    editable: false,
+    sortable: false,
+  },
+  {
+    headerName: "Size",
+    field: "size",
+    width: 150,
+    editable: false,
+    sortable: false,
+  },
+];
+const ignoreMetaColumns = [
+  "imageName",
+  "annotationProgress",
+  "assignees",
+  "labels",
+  "pixels",
+  "size",
+  "id",
+  "dimensions",
+];
+
+export function TableView({ metadata }: Props): ReactElement {
+  const colsObj = metadata.reduce((acc, el) => {
+    Object.keys(el).forEach((field) => {
+      if (!ignoreMetaColumns.includes(field)) {
+        acc[field] = {
+          field,
+          headerName: field, // TODO split on capital, make pretty
+          width: 150,
+          editable: false,
+          hide: true,
+          sortable: false,
+        };
+      }
+    });
+
+    return acc;
+  }, {} as { [index: string]: GridColDef });
+
+  const allCols = [...defaultColumns, ...Object.values(colsObj)];
+
+  return (
+    <Box sx={{ width: "100%", marginTop: "14px" }}>
+      <DataGrid
+        disableColumnFilter /* Sorting and filtering is handled externally */
+        title="Dataset Details"
+        columns={allCols}
+        rows={metadata}
+        sx={{ height: "82.7vh" }}
+        hideFooterPagination
+        pageSize={metadata.length}
+      />
+    </Box>
+  );
+}

--- a/src/TableView.tsx
+++ b/src/TableView.tsx
@@ -1,5 +1,5 @@
-import { ReactElement, useState } from "react";
-import type { GridSelectionModel } from "@mui/x-data-grid";
+import { ReactElement } from "react";
+
 import {
   DataGrid,
   Chip,

--- a/src/components/SizeThumbnails.tsx
+++ b/src/components/SizeThumbnails.tsx
@@ -3,10 +3,14 @@ import { IconButton, ButtonGroup } from "@gliff-ai/style";
 import { thumbnailSizes, ThumbnailSizes } from "@/components/Tooltips";
 
 interface Props {
+  disabled: boolean;
   resizeThumbnails: (size: number) => void;
 }
 
-export function SizeThumbnails({ resizeThumbnails }: Props): ReactElement {
+export function SizeThumbnails({
+  resizeThumbnails,
+  disabled,
+}: Props): ReactElement {
   const [buttonClicked, setButtonClicked] = useState("Small Thumbnails");
 
   useEffect(() => {
@@ -27,6 +31,7 @@ export function SizeThumbnails({ resizeThumbnails }: Props): ReactElement {
     >
       {thumbnailSizes.map(({ name, icon, id }: ThumbnailSizes) => (
         <IconButton
+          disabled={disabled}
           id={id}
           key={name}
           sx={{ padding: "5px" }}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -67,8 +67,9 @@ function getKeyType(metadata: Metadata, key: string): string {
 function sortMetadata(
   metadata: Metadata,
   key: string,
-  acending = true
+  ascending = true
 ): Metadata | null {
+  const metaCopy = [...metadata];
   const metaType = getKeyType(metadata, key);
 
   function toDate(value: string): Date {
@@ -77,28 +78,28 @@ function sortMetadata(
 
   switch (metaType) {
     case "number":
-      metadata.sort((a: MetaItem, b: MetaItem): number =>
-        compare(a[key] as number, b[key] as number, acending)
+      metaCopy.sort((a: MetaItem, b: MetaItem): number =>
+        compare(a[key] as number, b[key] as number, ascending)
       );
-      return metadata;
+      return metaCopy;
     case "date":
-      metadata.sort((a, b): number =>
-        compare(toDate(a[key] as string), toDate(b[key] as string), acending)
+      metaCopy.sort((a, b): number =>
+        compare(toDate(a[key] as string), toDate(b[key] as string), ascending)
       );
-      return metadata;
+      return metaCopy;
 
     case "string":
-      metadata.sort((a: MetaItem, b: MetaItem): number =>
-        compare(a[key] as number, b[key] as number, acending)
+      metaCopy.sort((a: MetaItem, b: MetaItem): number =>
+        compare(a[key] as number, b[key] as number, ascending)
       );
-      return metadata;
+      return metaCopy;
 
     case "undefined":
-      console.log(`No values set for metadata key "${key}".`);
+      console.warn(`No values set for metadata key "${key}".`);
       return null;
 
     default:
-      console.log(`Cannot sort values with type "${metaType}".`);
+      console.warn(`Cannot sort values with type "${metaType}".`);
       return null;
   }
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,6 +18,7 @@ type MetaItem = {
   id?: string;
   imageName?: string;
   imageLabels?: string[];
+  selected?: boolean; // TODO change this to "filtered" or something
 };
 
 type Filter = {

--- a/src/sort/SortPopover.tsx
+++ b/src/sort/SortPopover.tsx
@@ -33,15 +33,15 @@ export const SortPopover = ({
     label: "",
   });
 
-  const [sortOrder, setSortOrder] = useState("");
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const [metadataLabels, setMetadataLabels] = useState<MetadataLabel[]>([]);
 
   const handleChange =
-    (func: (value: string) => void) =>
+    <T extends string>(func: (value: T) => void) =>
     (event: ChangeEvent<HTMLInputElement>): void => {
       event.preventDefault();
       const { value } = event.target as HTMLButtonElement;
-      func(value);
+      func(value as T);
     };
 
   const updateKey = (selectedLabel: string): void => {
@@ -88,8 +88,8 @@ export const SortPopover = ({
             id="select-metadata-key"
             select
             value={inputKey.label}
-            onChange={handleChange(updateKey)}
-            helperText="Please select a metadata field"
+            onChange={handleChange<string>(updateKey)}
+            helperText={!inputKey.label ? "Please select a metadata field" : ""}
             variant="standard"
           >
             {metadataLabels &&
@@ -106,36 +106,42 @@ export const SortPopover = ({
           square
           style={{ padding: "10px", marginLeft: "15px" }}
         >
-          {/* Form for selecting a sort order */}
-          <FormControl component="fieldset">
-            <RadioGroup
-              aria-label="sort-order"
-              name="sort-order"
-              value={sortOrder}
-              onChange={handleChange(setSortOrder)}
-            >
+          {inputKey.label ? (
+            <>
+              {/* Form for selecting a sort order */}
+              <FormControl component="fieldset">
+                <RadioGroup
+                  aria-label="sort-order"
+                  name="sort-order"
+                  value={sortOrder}
+                  onChange={handleChange<"asc" | "desc">(setSortOrder)}
+                >
+                  <FormControlLabel
+                    value="asc"
+                    control={<Radio size="small" />}
+                    label="Sort by ASC"
+                  />
+                  <FormControlLabel
+                    value="desc"
+                    control={<Radio size="small" />}
+                    label="Sort by DESC"
+                  />
+                </RadioGroup>
+              </FormControl>
               <FormControlLabel
-                value="asc"
-                control={<Radio size="small" />}
-                label="Sort by ASC"
+                control={
+                  <Checkbox
+                    checked={isGrouped}
+                    onChange={toggleIsGrouped}
+                    name="group-by"
+                  />
+                }
+                label="Group by value"
               />
-              <FormControlLabel
-                value="desc"
-                control={<Radio size="small" />}
-                label="Sort by DESC"
-              />
-            </RadioGroup>
-          </FormControl>
-          <FormControlLabel
-            control={
-              <Checkbox
-                checked={isGrouped}
-                onChange={toggleIsGrouped}
-                name="group-by"
-              />
-            }
-            label="Group by value"
-          />
+            </>
+          ) : (
+            <></>
+          )}
         </Paper>
         <BaseTextButton
           text="Sort"

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -591,7 +591,10 @@ class UserInterface extends Component<Props, State> {
           sx={{ marginBottom: "10px" }}
         >
           <MuiCard>
-            <SizeThumbnails resizeThumbnails={this.resizeThumbnails} />
+            <SizeThumbnails
+              disabled={this.state.datasetViewType !== "View Dataset as Images"}
+              resizeThumbnails={this.resizeThumbnails}
+            />
           </MuiCard>
           <MuiCard>
             <DatasetViewToggle

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -28,13 +28,7 @@ import {
   Box,
   ThemeProvider,
   StyledEngineProvider,
-  DataGrid,
-  Chip,
   ButtonGroup,
-  Typography,
-  GridRenderCellParams,
-  GridColDef,
-  HtmlTooltip,
 } from "@gliff-ai/style";
 
 import Tile, {
@@ -56,7 +50,8 @@ import type { Metadata, MetaItem, Filter, Profile } from "./interfaces";
 import { SearchBar, LabelsFilterAccordion, SearchFilterCard } from "@/search";
 import { sortMetadata, filterMetadata } from "@/helpers";
 import { PluginObject, PluginsAccordion } from "./components/plugins";
-import { DatasetView } from "./components/DatasetView";
+import { DatasetView as DatasetViewToggle } from "./components/DatasetView";
+import { TableView } from "./TableView";
 
 const bottomLeftButtons = {
   display: "flex",
@@ -246,7 +241,6 @@ class UserInterface extends Component<Props, State> {
   applySearchFiltersToMetadata = (): void => {
     this.setState(({ metadata, activeFilters }) => {
       const newMetadata = filterMetadata(metadata, activeFilters);
-
       return newMetadata ? { metadata } : undefined;
     });
 
@@ -318,9 +312,7 @@ class UserInterface extends Component<Props, State> {
   };
 
   handleOnSortSubmit = (key: string, sortOrder: string): void => {
-    // Handle sort by key
-
-    if (key === "") return; // for some reason this function is being called on startup with an empty key
+    if (key === "") return;
 
     this.setState(({ metadata }: State) => {
       const newMetadata = sortMetadata(metadata, key, sortOrder === "asc");
@@ -330,6 +322,8 @@ class UserInterface extends Component<Props, State> {
     if (this.state.isGrouped) {
       this.groupByValue(key);
     }
+
+    // TODO: Close the sort popup?
   };
 
   groupByValue = (key: string): void => {
@@ -600,7 +594,9 @@ class UserInterface extends Component<Props, State> {
             <SizeThumbnails resizeThumbnails={this.resizeThumbnails} />
           </MuiCard>
           <MuiCard>
-            <DatasetView changeDatasetViewType={this.changeDatasetViewType} />
+            <DatasetViewToggle
+              changeDatasetViewType={this.changeDatasetViewType}
+            />
           </MuiCard>
         </Box>
         <Box
@@ -699,103 +695,6 @@ class UserInterface extends Component<Props, State> {
           </ButtonGroup>
         </List>
       </MuiCard>
-    );
-
-    const defaultColumns = [
-      {
-        headerName: "Image Name",
-        field: "imageName",
-        width: 150,
-        editable: false,
-      },
-      {
-        headerName: "Annotation Progress",
-        field: "annotationProgress",
-        width: 250,
-        editable: false,
-      },
-      {
-        headerName: "Assignees",
-        field: "assignees",
-        width: 300,
-        editable: false,
-      },
-      {
-        headerName: "Labels",
-        field: "labels",
-        width: 250,
-        editable: false,
-        renderCell: (params: GridRenderCellParams<unknown, MetaItem>) => {
-          const { imageLabels = [] } = params.row;
-          const chipsLimit = 2;
-          const chipsContent: string[] = imageLabels.slice(0, chipsLimit);
-          const moreLabelsCount = imageLabels.length - chipsLimit;
-          const showPlaceholder =
-            moreLabelsCount > 0 ? (
-              <HtmlTooltip title={imageLabels.join(", ")} placement="bottom">
-                <Typography>+ {moreLabelsCount} more</Typography>
-              </HtmlTooltip>
-            ) : null;
-          const chips = chipsContent.map((imageLabel: string) => (
-            <Chip label={imageLabel} key={imageLabel} variant="outlined" />
-          ));
-          return [chips, showPlaceholder];
-        },
-      },
-
-      {
-        headerName: "Pixels",
-        field: "dimensions",
-        width: 150,
-        editable: false,
-      },
-      {
-        headerName: "Size",
-        field: "size",
-        width: 150,
-        editable: false,
-      },
-    ];
-    const ignoreMetaColumns = [
-      "imageName",
-      "annotationProgress",
-      "assignees",
-      "labels",
-      "pixels",
-      "size",
-      "id",
-      "dimensions",
-    ];
-
-    const colsObj = this.state.metadata.reduce((acc, el) => {
-      Object.keys(el).forEach((k) => {
-        if (!ignoreMetaColumns.includes(k)) {
-          acc[k] = {
-            field: k,
-            headerName: k, // TODO split on capital, make pretty
-            width: 150,
-            editable: false,
-            hide: true,
-          };
-        }
-      });
-
-      return acc;
-    }, {} as { [index: string]: GridColDef });
-
-    const allCols = [...defaultColumns, ...Object.values(colsObj)];
-
-    const tableView = (
-      <Box sx={{ width: "100%", marginTop: "14px" }}>
-        <DataGrid
-          title="Dataset Details"
-          columns={allCols}
-          rows={this.state.metadata}
-          sx={{ height: "82.7vh" }}
-          hideFooterPagination
-          pageSize={this.state.metadata.length}
-        />
-      </Box>
     );
 
     const imagesView = this.state.metadata
@@ -1030,22 +929,26 @@ class UserInterface extends Component<Props, State> {
                         onClick={this.props.downloadDatasetCallback}
                       />
                     </MuiCard>
-                    <MuiCard sx={{ ...smallButton }}>
-                      <IconButton
-                        tooltip={tooltips.selectMultipleImages}
-                        fill={this.state.selectMultipleImagesMode}
-                        icon={tooltips.selectMultipleImages.icon}
-                        tooltipPlacement="bottom"
-                        onClick={() => {
-                          this.setState((prevState) => ({
-                            selectMultipleImagesMode:
-                              !prevState.selectMultipleImagesMode,
-                          }));
-                        }}
-                        id="select-multiple-images"
-                        size="small"
-                      />
-                    </MuiCard>
+                    {this.state.datasetViewType !== "View Dataset as Table" ? (
+                      <MuiCard sx={{ ...smallButton }}>
+                        <IconButton
+                          tooltip={tooltips.selectMultipleImages}
+                          fill={this.state.selectMultipleImagesMode}
+                          icon={tooltips.selectMultipleImages.icon}
+                          tooltipPlacement="bottom"
+                          onClick={() => {
+                            this.setState((prevState) => ({
+                              selectMultipleImagesMode:
+                                !prevState.selectMultipleImagesMode,
+                            }));
+                          }}
+                          id="select-multiple-images"
+                          size="small"
+                        />
+                      </MuiCard>
+                    ) : (
+                      ""
+                    )}
                   </Box>
                 </Grid>
                 <Grid
@@ -1058,9 +961,15 @@ class UserInterface extends Component<Props, State> {
                     flexWrap: "wrap",
                   }}
                 >
-                  {this.state.datasetViewType === "View Dataset as Images"
-                    ? imagesView
-                    : tableView}
+                  {this.state.datasetViewType === "View Dataset as Images" ? (
+                    imagesView
+                  ) : (
+                    <TableView
+                      metadata={this.state.metadata.filter(
+                        (mitem) => mitem.selected
+                      )}
+                    />
+                  )}
                 </Grid>
               </Grid>
             </Container>


### PR DESCRIPTION
## Description

Minor datatable changes, addresses some of https://github.com/gliff-ai/curate/issues/417 (which i only saw after doing them...it doesn't aim to solve all the points in that issue, just some of the easy wins/obviously broken parts)

- It now works with sort/filter on the side bar (and removes those options from the columns)
- Add some small typings
- Move DataTable into new file to make ui.tsx very slightly neater
- Hide 'multiselect' button when on table view
- Disable thumbnail size on table view
- minor polish on sort popover

One thing that _isn't_ supported in DataTable is groupBy unless we give MUI the dollars. Not sure if we need a way in the UI to indicate that @joshuajames-smith ? 

Created 2 follow on issues:

https://github.com/gliff-ai/curate/issues/423
https://github.com/gliff-ai/curate/issues/422
