### PR TITLE
fix: remove upload from bundle

### DIFF
--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     minify: false, // TODO maybe?
     lib: {
       entry: path.resolve(__dirname, "src/index.tsx"),
-      name: "@gliff-ai/manage",
+      name: "@gliff-ai/curate",
       formats: ["es"],
       fileName: "index",
     },
@@ -21,9 +21,11 @@ export default defineConfig({
         "@mui/icons-material",
         "@mui/styles",
         "@mui/system",
+        "@mui/x-data-grid",
         "@emotion/react",
         "@emotion/styled",
         "@gliff-ai/style",
+        "@gliff-ai/upload",
       ],
       output: {
         globals: {},


### PR DESCRIPTION
It's a peer dep, but we still bundle it, which makes the lib _fat_ (and also means upstream we have multiple versions of upload loaded which we certainly don't want)