### PR TITLE
feat: Centralise selection state to share between Tile/Grid view

### DIFF
--- a/src/MetadataDrawer.tsx
+++ b/src/MetadataDrawer.tsx
@@ -177,7 +177,7 @@ export default function MetadataDrawer(props: Props): ReactElement {
                   <ListItemText
                     primaryTypographyProps={{ variant: "h6" }}
                     className={classes.metaKey}
-                    title={metadataNameMap[key] || key}
+                    title={`${metadataNameMap[key] || key}`}
                     primary={`${metadataNameMap[key] || key}:`}
                     classes={{
                       primary: classes.metaKey,
@@ -186,7 +186,7 @@ export default function MetadataDrawer(props: Props): ReactElement {
                   />
                   <ListItemText
                     className={classes.metaValue}
-                    title={props.metadata[key] as string}
+                    title={`${props.metadata[key] as string}`}
                     primary={
                       key === "imageLabels"
                         ? props.metadata[key].join(", ")

--- a/src/TableView.tsx
+++ b/src/TableView.tsx
@@ -113,7 +113,7 @@ export function TableView({ metadata }: Props): ReactElement {
         disableColumnFilter /* Sorting and filtering is handled externally */
         title="Dataset Details"
         columns={allCols}
-        rows={metadata}
+        rows={metadata.filter((mitem) => mitem.filterShow)}
         sx={{ height: "82.7vh" }}
         hideFooterPagination
         pageSize={metadata.length}

--- a/src/TableView.tsx
+++ b/src/TableView.tsx
@@ -115,7 +115,6 @@ export function TableView({ metadata, ...props }: Props): ReactElement {
   }, {} as { [index: string]: GridColDef });
 
   const allCols = [...defaultColumns, ...Object.values(colsObj)];
-  const shownMeta = metadata.filter((mitem) => mitem.filterShow);
 
   return (
     <Box sx={{ width: "100%", marginTop: "14px" }}>
@@ -123,19 +122,16 @@ export function TableView({ metadata, ...props }: Props): ReactElement {
         disableColumnFilter /* Sorting and filtering is handled externally */
         title="Dataset Details"
         columns={allCols}
-        rows={shownMeta}
+        rows={metadata}
         sx={{ height: "82.7vh" }}
         hideFooterPagination
-        pageSize={shownMeta.length}
-        onSelectionModelChange={(newSelectionModel) => {
-          // NewSelectionModel is indexes, we want to use our ids
+        pageSize={metadata.length}
+        onSelectionModelChange={(newSelectionModel) =>
           dispatch({
             type: "set",
-            id: newSelectionModel.map(
-              (rowIndex: number) => shownMeta?.[rowIndex]?.id
-            ),
-          });
-        }}
+            id: newSelectionModel as string[], // MetaItem.id is a string
+          })
+        }
         selectionModel={[...selectedImagesUid]}
       />
     </Box>

--- a/src/TileView.tsx
+++ b/src/TileView.tsx
@@ -64,88 +64,88 @@ export function TileView({
 
   return (
     <>
-      {metadata
-        .filter((mitem) => mitem.filterShow)
-        .map((mitem: MetaItem, itemIndex) => (
-          <Fragment key={mitem.id}>
-            {isGrouped && (
-              <GroupBySeparator mitem={mitem} sortedBy={sortedBy} />
-            )}
-            <Grid
-              item
-              style={{
-                backgroundColor:
-                  selectedImagesUid.has(mitem.id) && theme.palette.primary.main,
+      {metadata.map((mitem: MetaItem, itemIndex) => (
+        <Fragment key={mitem.id}>
+          {isGrouped && <GroupBySeparator mitem={mitem} sortedBy={sortedBy} />}
+          <Grid
+            item
+            style={{
+              backgroundColor:
+                selectedImagesUid.has(mitem.id) && theme.palette.primary.main,
+            }}
+          >
+            <Box
+              sx={{
+                position: "relative" as const,
+                "& > button": {
+                  margin: "5px",
+                },
               }}
             >
-              <Box
-                sx={{
-                  position: "relative" as const,
-                  "& > button": {
-                    margin: "5px",
-                  },
+              <Button
+                id="images"
+                onClick={(e: MouseEvent) => {
+                  const { id } = mitem;
+                  if (e.metaKey || e.ctrlKey || selectMultipleImagesMode) {
+                    // Add image to selection if not included, otherwise remove it
+                    dispatch({ type: "toggle", id });
+                  } else if (e.shiftKey && selectedImagesUid.size > 0) {
+                    // Selected all images between a pair of clicked images.
+                    const currIdx = getIndexFromUid(id);
+                    const prevIdx = getIndexFromUid(getLastSelection());
+                    dispatch({ type: "add", id: metadata[prevIdx].id });
+                    const startIdx = prevIdx < currIdx ? prevIdx : currIdx;
+                    const endIdx = prevIdx < currIdx ? currIdx : prevIdx;
+
+                    for (let i = startIdx; i <= endIdx; i += 1) {
+                      dispatch({ type: "add", id: metadata[i].id });
+                    }
+                  } else {
+                    // Select single item
+                    dispatch({ type: "set", id: [id] });
+                  }
+                }}
+                onDoubleClick={() => {
+                  onDoubleClick(mitem.id);
+                }}
+                onKeyDown={(e: KeyboardEvent) => {
+                  if (e.key === "Escape") {
+                    // Deselect all
+                    dispatch({ type: "set", id: [] });
+                    return;
+                  }
+
+                  if (
+                    e.shiftKey &&
+                    (e.key === "ArrowLeft" || e.key === "ArrowRight")
+                  ) {
+                    // Select consecutive images to the left or to the right of the clicked image.
+                    const index = getItemUidNextToLastSelected(
+                      e.key === "ArrowRight"
+                    );
+
+                    if (index !== null) {
+                      const { id } = metadata[index];
+                      if (selectedImagesUid.has(id)) {
+                        dispatch({ type: "delete", id: getLastSelection() });
+                      } else {
+                        dispatch({ type: "add", id });
+                      }
+                    }
+                  }
                 }}
               >
-                <Button
-                  id="images"
-                  onClick={(e: MouseEvent) => {
-                    const { id } = mitem;
-                    if (e.metaKey || e.ctrlKey || selectMultipleImagesMode) {
-                      // Add image to selection if not included, otherwise remove it
-                      dispatch({ type: "toggle", id });
-                    } else if (e.shiftKey && selectedImagesUid.size > 0) {
-                      // Selected all images between a pair of clicked images.
-                      const currIdx = getIndexFromUid(id);
-                      const prevIdx = getIndexFromUid(getLastSelection());
-                      dispatch({ type: "add", id: metadata[prevIdx].id });
-                      const startIdx = prevIdx < currIdx ? prevIdx : currIdx;
-                      const endIdx = prevIdx < currIdx ? currIdx : prevIdx;
-
-                      for (let i = startIdx; i <= endIdx; i += 1) {
-                        dispatch({ type: "add", id: metadata[i].id });
-                      }
-                    } else {
-                      // Select single item
-                      dispatch({ type: "set", id: [id] });
-                    }
-                  }}
-                  onDoubleClick={() => {
-                    onDoubleClick(mitem.id);
-                  }}
-                  onKeyDown={(e: KeyboardEvent) => {
-                    if (
-                      e.shiftKey &&
-                      (e.key === "ArrowLeft" || e.key === "ArrowRight")
-                    ) {
-                      // Select consecutive images to the left or to the right of the clicked image.
-                      const index = getItemUidNextToLastSelected(
-                        e.key === "ArrowRight"
-                      );
-                      if (index !== null) {
-                        const { id } = metadata[index];
-                        if (selectedImagesUid.has(id)) {
-                          dispatch({ type: "delete", id: getLastSelection() });
-                        } else {
-                          dispatch({ type: "add", id: getLastSelection() });
-                        }
-                      }
-                    } else if (e.key === "Escape") {
-                      // Deselect all
-                      dispatch({ type: "set", id: [] });
-                    }
-                  }}
-                >
-                  <Tile
-                    mitem={mitem}
-                    width={thumbnailSize}
-                    height={thumbnailSize}
-                  />
-                </Button>
-                {labelsPopover(mitem, itemIndex)}
-              </Box>
-            </Grid>
-          </Fragment>
-        ))}
+                <Tile
+                  mitem={mitem}
+                  width={thumbnailSize}
+                  height={thumbnailSize}
+                />
+              </Button>
+              {labelsPopover(mitem, itemIndex)}
+            </Box>
+          </Grid>
+        </Fragment>
+      ))}
     </>
   );
 }

--- a/src/TileView.tsx
+++ b/src/TileView.tsx
@@ -23,10 +23,7 @@ interface Props {
   selectMultipleImagesMode: boolean;
   onDoubleClick: (id: string) => void;
   labelsPopover: (mitem: MetaItem, i: number) => JSX.Element;
-  selectedImagesUid: [
-    Set<string>,
-    (action: SelectedImagesAction) => Set<string>
-  ];
+  selectedImagesUid: [Set<string>, (action: SelectedImagesAction) => void];
 }
 
 export function TileView({

--- a/src/TileView.tsx
+++ b/src/TileView.tsx
@@ -1,0 +1,154 @@
+import { KeyboardEvent, MouseEvent, Fragment, ReactElement } from "react";
+import { theme, Grid, Button, Box } from "@gliff-ai/style";
+
+import { Metadata, MetaItem } from "@/interfaces";
+import { Tile } from "@/components";
+import { GroupBySeparator } from "@/sort";
+
+type SelectedImagesAction =
+  | {
+      type: "add" | "delete" | "toggle";
+      id: string;
+    }
+  | {
+      type: "set";
+      id: string[];
+    };
+
+interface Props {
+  metadata: Metadata;
+  isGrouped: boolean;
+  sortedBy: string;
+  thumbnailSize: number;
+  selectMultipleImagesMode: boolean;
+  onDoubleClick: (id: string) => void;
+  labelsPopover: (mitem: MetaItem, i: number) => JSX.Element;
+  selectedImagesUid: [
+    Set<string>,
+    (action: SelectedImagesAction) => Set<string>
+  ];
+}
+
+export function TileView({
+  metadata,
+  isGrouped,
+  sortedBy,
+  selectMultipleImagesMode,
+  labelsPopover,
+  thumbnailSize,
+  onDoubleClick,
+  ...props
+}: Props): ReactElement {
+  const [selectedImagesUid, dispatch] = props.selectedImagesUid; // same as useReduce, but state is in parent
+  const getLastSelection = () => [...selectedImagesUid.values()].pop();
+
+  const getIndexFromUid = (uid: string): number | null => {
+    for (let i = 0; i < metadata.length; i += 1) {
+      if (metadata[i].id === uid) return i;
+    }
+    return null;
+  };
+
+  const getItemUidNextToLastSelected = (forward = true): number | null => {
+    const inc = forward ? 1 : -1;
+    let index: number;
+    for (let i = 0; i < metadata.length; i += 1) {
+      index = i + inc;
+      if (
+        metadata[i].id === getLastSelection() &&
+        index < metadata.length &&
+        index >= 0
+      ) {
+        return index;
+      }
+    }
+    return null;
+  };
+
+  return (
+    <>
+      {metadata
+        .filter((mitem) => mitem.filterShow)
+        .map((mitem: MetaItem, itemIndex) => (
+          <Fragment key={mitem.id}>
+            {isGrouped && (
+              <GroupBySeparator mitem={mitem} sortedBy={sortedBy} />
+            )}
+            <Grid
+              item
+              style={{
+                backgroundColor:
+                  selectedImagesUid.has(mitem.id) && theme.palette.primary.main,
+              }}
+            >
+              <Box
+                sx={{
+                  position: "relative" as const,
+                  "& > button": {
+                    margin: "5px",
+                  },
+                }}
+              >
+                <Button
+                  id="images"
+                  onClick={(e: MouseEvent) => {
+                    const { id } = mitem;
+                    if (e.metaKey || e.ctrlKey || selectMultipleImagesMode) {
+                      // Add image to selection if not included, otherwise remove it
+                      dispatch({ type: "toggle", id });
+                    } else if (e.shiftKey && selectedImagesUid.size > 0) {
+                      // Selected all images between a pair of clicked images.
+                      const currIdx = getIndexFromUid(id);
+                      const prevIdx = getIndexFromUid(getLastSelection());
+                      dispatch({ type: "add", id: metadata[prevIdx].id });
+                      const startIdx = prevIdx < currIdx ? prevIdx : currIdx;
+                      const endIdx = prevIdx < currIdx ? currIdx : prevIdx;
+
+                      for (let i = startIdx; i <= endIdx; i += 1) {
+                        dispatch({ type: "add", id: metadata[i].id });
+                      }
+                    } else {
+                      // Select single item
+                      dispatch({ type: "set", id: [id] });
+                    }
+                  }}
+                  onDoubleClick={() => {
+                    onDoubleClick(mitem.id);
+                  }}
+                  onKeyDown={(e: KeyboardEvent) => {
+                    if (
+                      e.shiftKey &&
+                      (e.key === "ArrowLeft" || e.key === "ArrowRight")
+                    ) {
+                      // Select consecutive images to the left or to the right of the clicked image.
+                      const index = getItemUidNextToLastSelected(
+                        e.key === "ArrowRight"
+                      );
+                      if (index !== null) {
+                        const { id } = metadata[index];
+                        if (selectedImagesUid.has(id)) {
+                          dispatch({ type: "delete", id: getLastSelection() });
+                        } else {
+                          dispatch({ type: "add", id: getLastSelection() });
+                        }
+                      }
+                    } else if (e.key === "Escape") {
+                      // Deselect all
+                      dispatch({ type: "set", id: [] });
+                    }
+                  }}
+                >
+                  <Tile
+                    mitem={mitem}
+                    width={thumbnailSize}
+                    height={thumbnailSize}
+                  />
+                </Button>
+                {labelsPopover(mitem, itemIndex)}
+              </Box>
+            </Grid>
+          </Fragment>
+        ))}
+    </>
+  );
+}

--- a/src/components/AutoAssignDialog.tsx
+++ b/src/components/AutoAssignDialog.tsx
@@ -114,7 +114,7 @@ export function AutoAssignDialog(props: Props): ReactElement {
   function updateInfo(): void {
     if (!imageUids) return;
 
-    const assigneesLenghts = props.metadata
+    const assigneesLengths = props.metadata
       .filter(
         ({ id, assignees }) =>
           imageUids.includes(id as string) &&
@@ -123,11 +123,11 @@ export function AutoAssignDialog(props: Props): ReactElement {
       .map(({ assignees }) => (assignees as string[]).length);
 
     setInfo({
-      hasAssignedImages: assigneesLenghts.length > 0,
-      hasUnevenNumOfAssignees: assigneesLenghts.some(
-        (l) => l !== assigneesLenghts[0]
+      hasAssignedImages: assigneesLengths.length > 0,
+      hasUnevenNumOfAssignees: assigneesLengths.some(
+        (l) => l !== assigneesLengths[0]
       ),
-      maxNumOfAssignees: Math.max(Math.max.apply(Math, assigneesLenghts), 1),
+      maxNumOfAssignees: Math.max(Math.max.apply(Math, assigneesLengths), 1),
     });
   }
 
@@ -270,10 +270,10 @@ export function AutoAssignDialog(props: Props): ReactElement {
         id: string;
         assignees: string[];
       };
-      const assigneesLenght = assignees.length;
+      const assigneesLength = assignees.length;
 
       // if image is fully assigned
-      if (assigneesLenght === assigneesPerImage) {
+      if (assigneesLength === assigneesPerImage) {
         const index = allCombs.indexOf(JSON.stringify(assignees.sort()));
 
         if (index === -1) {
@@ -286,7 +286,7 @@ export function AutoAssignDialog(props: Props): ReactElement {
         // if image is partially assigned
       } else {
         let currComb: string[];
-        if (assigneesLenght > 0 && assigneesLenght < assigneesPerImage) {
+        if (assigneesLength > 0 && assigneesLength < assigneesPerImage) {
           const viableCombs: string[][] = allCombs
             .filter(
               (comb, i, newCombs) =>

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from "react";
 import { MetaItem } from "@/interfaces";
 
-export default function Tile(props: {
+export function Tile(props: {
   mitem: MetaItem;
   width: number;
   height: number;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,6 +4,4 @@ export { LabelsPopover } from "./LabelsPopover";
 export { AssigneesDialog } from "./AssigneesDialog";
 export { AutoAssignDialog } from "./AutoAssignDialog";
 export { DefaultLabelsDialog } from "./DefaultLabelsDialog";
-
-import Tile from "./Tile";
-export default Tile;
+export { Tile } from "./Tile";

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,7 +1,8 @@
-import { Metadata, Filter } from "@/interfaces";
+import { Filter, MetaItem } from "@/interfaces";
 import { sortMetadata, filterMetadata } from "./helpers";
 
-const metadata: Metadata = [
+type TestMetaData = Partial<MetaItem>[];
+const metadata: Partial<MetaItem>[] = [
   {
     string: "through",
     date: "01-26-1920",
@@ -16,7 +17,7 @@ const metadata: Metadata = [
 ];
 
 function cloneMetadata() {
-  return metadata.map((mitem) => ({ ...mitem, selected: true }));
+  return metadata.map((mitem) => ({ ...mitem, selected: true } as MetaItem));
 }
 
 describe("sort metadata with missing values", () => {
@@ -47,7 +48,7 @@ describe("sort metadata with missing values", () => {
   );
 });
 
-const testFilter = (filters: Filter[], outcome: Metadata): void => {
+const testFilter = (filters: Filter[], outcome: TestMetaData): void => {
   const newMetadata = filterMetadata(cloneMetadata(), filters);
   expect(
     newMetadata

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -17,7 +17,7 @@ const metadata: Partial<MetaItem>[] = [
 ];
 
 function cloneMetadata() {
-  return metadata.map((mitem) => ({ ...mitem, selected: true } as MetaItem));
+  return metadata.map((mitem) => ({ ...mitem, filterShow: true } as MetaItem));
 }
 
 describe("sort metadata with missing values", () => {
@@ -52,8 +52,8 @@ const testFilter = (filters: Filter[], outcome: TestMetaData): void => {
   const newMetadata = filterMetadata(cloneMetadata(), filters);
   expect(
     newMetadata
-      .filter(({ selected }) => selected)
-      .map(({ selected, ...rest }) => rest)
+      .filter(({ filterShow }) => filterShow)
+      .map(({ filterShow, ...rest }) => rest)
   ).toEqual(outcome);
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -133,4 +133,47 @@ function filterMetadata(metadata: Metadata, activeFilters: Filter[]): Metadata {
   return metadata;
 }
 
-export { kCombinations, shuffle, sortMetadata, filterMetadata };
+const makeThumbnail = (image: Array<Array<ImageBitmap>>): string => {
+  const canvas = document.createElement("canvas");
+  canvas.width = 128;
+  canvas.height = 128;
+  const imageWidth = image[0][0].width;
+  const imageHeight = image[0][0].height;
+  const ratio = Math.min(
+    canvas.width / imageWidth,
+    canvas.height / imageHeight
+  );
+  const ctx = canvas.getContext("2d");
+  ctx.globalCompositeOperation = "lighter";
+  image[0].forEach((channel) => {
+    ctx.drawImage(
+      channel,
+      0,
+      0,
+      imageWidth,
+      imageHeight,
+      (canvas.width - imageWidth * ratio) / 2,
+      (canvas.height - imageHeight * ratio) / 2,
+      imageWidth * ratio,
+      imageHeight * ratio
+    );
+  });
+  return canvas.toDataURL();
+};
+
+const getMonthAndYear = (date: string): string =>
+  date !== undefined
+    ? new Date(date).toLocaleDateString("en-GB", {
+        month: "short",
+        year: "numeric",
+      })
+    : "";
+
+export {
+  kCombinations,
+  shuffle,
+  sortMetadata,
+  filterMetadata,
+  makeThumbnail,
+  getMonthAndYear,
+};

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -118,16 +118,16 @@ function filterMetadata(metadata: Metadata, activeFilters: Filter[]): Metadata {
         );
 
         // selection for all filters up to current
-        const prevSel = fi === 0 ? 1 : Number(mitem.selected);
+        const prevSel = fi === 0 ? 1 : Number(mitem.filterShow);
 
-        // update 'selected' field
-        mitem.selected = Boolean(prevSel * currentSel);
+        // update 'filterShow' field
+        mitem.filterShow = Boolean(prevSel * currentSel);
       });
     });
   } else {
     // all items selected
     metadata.forEach((mitem: MetaItem) => {
-      mitem.selected = true;
+      mitem.filterShow = true;
     });
   }
   return metadata;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,6 +19,7 @@ type MetaItem = {
   imageName?: string;
   imageLabels?: string[];
   filterShow?: boolean;
+  assignees?: string[];
   numberOfDimensions: "2" | "3"; // Not sure why these are strings?
   dimensions: string;
   size: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,7 +18,7 @@ type MetaItem = {
   id?: string;
   imageName?: string;
   imageLabels?: string[];
-  selected?: boolean; // TODO change this to "filtered" or something
+  filterShow?: boolean;
 };
 
 type Filter = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,6 +19,9 @@ type MetaItem = {
   imageName?: string;
   imageLabels?: string[];
   filterShow?: boolean;
+  numberOfDimensions: "2" | "3"; // Not sure why these are strings?
+  dimensions: string;
+  size: string;
 };
 
 type Filter = {

--- a/src/search/SearchBar.tsx
+++ b/src/search/SearchBar.tsx
@@ -3,7 +3,9 @@ import { ChangeEvent, useState, useEffect, ReactElement } from "react";
 
 import makeStyles from "@mui/styles/makeStyles";
 import { Card, CardContent, Paper, TextField } from "@mui/material";
-import Autocomplete, { AutocompleteRenderInputParams } from "@mui/material/Autocomplete";
+import Autocomplete, {
+  AutocompleteRenderInputParams,
+} from "@mui/material/Autocomplete";
 import { BaseIconButton, theme } from "@gliff-ai/style";
 import { metadataNameMap } from "@/MetadataDrawer";
 import { tooltips } from "@/components/Tooltips";
@@ -61,7 +63,14 @@ const getLabelsFromKeys = (
 ): MetadataLabel[] => {
   // Just an example of how to exclude metadata from the list if we need
   if (
-    ["fileMetaVersion", "id", "thumbnail", "selected", "newGroup"].includes(key)
+    [
+      "fileMetaVersion",
+      "id",
+      "thumbnail",
+      "selected",
+      "newGroup",
+      "filterShow",
+    ].includes(key)
   )
     return acc;
 
@@ -88,7 +97,7 @@ function SearchBar({
     if (!inputKey?.key || !metadataKeys.includes(inputKey.key)) return;
     const options: Set<string> = new Set();
     metadata.forEach((mitem: MetaItem) => {
-      if (mitem.selected && mitem[inputKey.key] !== undefined) {
+      if (mitem.filterShow && mitem[inputKey.key] !== undefined) {
         const value = mitem[inputKey.key];
         if (Array.isArray(value)) {
           value.forEach((v) => options.add(v));

--- a/src/sort/GroupBySeparator.tsx
+++ b/src/sort/GroupBySeparator.tsx
@@ -1,7 +1,8 @@
 import { ReactElement } from "react";
 import { Grid } from "@mui/material";
-import makeStyles from '@mui/styles/makeStyles';
+import makeStyles from "@mui/styles/makeStyles";
 import { MetaItem } from "@/interfaces";
+import { getMonthAndYear } from "@/helpers";
 
 const useStyles = makeStyles({
   container: { width: "100%", height: "100%" },
@@ -9,7 +10,7 @@ const useStyles = makeStyles({
     margin: "0 10px",
     paddingLeft: "5px",
     fontSize: "20px",
-    fontWeigth: 500,
+    fontWeight: 500,
     borderBottom: "solid 2px",
   },
 });
@@ -17,14 +18,9 @@ const useStyles = makeStyles({
 interface Props {
   mitem: MetaItem;
   sortedBy: string;
-  getMonthAndYear: (date: string) => string;
 }
 
-function GroupBySeparator({
-  mitem,
-  sortedBy,
-  getMonthAndYear,
-}: Props): ReactElement {
+function GroupBySeparator({ mitem, sortedBy }: Props): ReactElement {
   const classes = useStyles();
 
   return sortedBy && mitem.newGroup ? (

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -95,7 +95,7 @@ interface Props {
   profiles?: Profile[] | null;
   userAccess?: UserAccess;
   launchPluginSettingsCallback?: (() => void) | null;
-  saveMetadataCallback?: ((data: any) => void) | null;
+  saveMetadataCallback?: ((data: unknown) => void) | null;
   restrictLabels?: boolean; // restrict image labels to defaultLabels
   multiLabel?: boolean;
 }
@@ -225,7 +225,7 @@ class UserInterface extends Component<Props, State> {
   };
 
   // This can be swapped out for useReducer when this is a functional
-  dispatchSelectedImagesUid = (action: SelectedImagesAction) => {
+  dispatchSelectedImagesUid = (action: SelectedImagesAction): void => {
     function reducer(
       oldState: Set<string>,
       { type, id }: SelectedImagesAction
@@ -495,7 +495,7 @@ class UserInterface extends Component<Props, State> {
     let currentAssignees: string[] = [];
     this.state.metadata.forEach(({ id, assignees }) => {
       if (this.state.selectedImagesUid.has(id)) {
-        currentAssignees = currentAssignees.concat(assignees as string[]);
+        currentAssignees = currentAssignees.concat(assignees);
       }
     });
     return Array.from(new Set(currentAssignees));
@@ -706,17 +706,11 @@ class UserInterface extends Component<Props, State> {
                   {this.state.selectedImagesUid.size === 1 &&
                   !this.state.selectMultipleImagesMode ? (
                     <MetadataDrawer
-                      metadata={this.state.metadata.find(({ id }) => {
-                        console.log("drawer");
-                        console.log(id);
-                        console.log(this.state.selectedImagesUid);
-
-                        // TODO fix selectiong single item when filterd
-                        return (
+                      metadata={this.state.metadata.find(
+                        ({ id }) =>
                           id ===
                           [...this.state.selectedImagesUid.values()].pop()
-                        );
-                      })}
+                      )}
                       close={() => {
                         // deselect the image to close the drawer
                         this.setState({ selectedImagesUid: new Set() });
@@ -827,7 +821,9 @@ class UserInterface extends Component<Props, State> {
                 >
                   {this.state.datasetViewType === "View Dataset as Images" ? (
                     <TileView
-                      metadata={this.state.metadata}
+                      metadata={this.state.metadata.filter(
+                        (mitem) => mitem.filterShow
+                      )}
                       selectedImagesUid={[
                         this.state.selectedImagesUid,
                         this.dispatchSelectedImagesUid,
@@ -855,7 +851,9 @@ class UserInterface extends Component<Props, State> {
                     />
                   ) : (
                     <TableView
-                      metadata={this.state.metadata}
+                      metadata={this.state.metadata.filter(
+                        (mitem) => mitem.filterShow
+                      )}
                       selectedImagesUid={[
                         this.state.selectedImagesUid,
                         this.dispatchSelectedImagesUid,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -216,7 +216,7 @@ class UserInterface extends Component<Props, State> {
     // Select all items and empty active filters array.
     this.setState((prevState) => {
       prevState.metadata.forEach((mitem) => {
-        mitem.selected = true;
+        mitem.filterShow = true;
       });
       return { activeFilters: [], metadata: prevState.metadata };
     });
@@ -259,12 +259,12 @@ class UserInterface extends Component<Props, State> {
       prevState.metadata.forEach((mitem) => {
         if (selectedLabels === null) {
           // select all unlabelled images
-          mitem.selected = mitem.imageLabels.length === 0;
+          mitem.filterShow = mitem.imageLabels.length === 0;
         } else {
           const intersection = mitem.imageLabels.filter((l) =>
             selectedLabels.includes(l)
           );
-          mitem.selected = intersection.length === selectedLabels.length;
+          mitem.filterShow = intersection.length === selectedLabels.length;
         }
       });
 
@@ -342,7 +342,7 @@ class UserInterface extends Component<Props, State> {
     let prevValue: unknown = null;
     this.setState(({ metadata }) => {
       metadata.forEach((mitem) => {
-        if (!mitem.selected) return;
+        if (!mitem.filterShow) return;
         // Number.MAX_VALUE added to handle missing values
         const value = (mitem[key] as string) || Number.MAX_VALUE;
         if (!prevValue || areValuesEqual(value, prevValue)) {
@@ -705,7 +705,7 @@ class UserInterface extends Component<Props, State> {
     );
 
     const imagesView = this.state.metadata
-      .filter((mitem) => mitem.selected)
+      .filter((mitem) => mitem.filterShow)
       .map((mitem: MetaItem, itemIndex) => (
         <Fragment key={mitem.id}>
           {this.state.isGrouped && (
@@ -973,7 +973,7 @@ class UserInterface extends Component<Props, State> {
                   ) : (
                     <TableView
                       metadata={this.state.metadata.filter(
-                        (mitem) => mitem.selected
+                        (mitem) => mitem.filterShow
                       )}
                     />
                   )}


### PR DESCRIPTION
## Description

- Move TileView out of UI.tsx into a new file, to match TableView
- Move the image selection state into UI, and then pass the value and an update function into both views, so they're in sync and work with our external sort and filter.
  - It's now a Set rather than an array as then me don't need ot do as much management of duplicates etc
  - It's a reducer, if Ui.tsx was functional, it's an easy swap to `useReducer` hook.
- `assigneesLenght` -> `assigneesLength` everywhere 😀 
- Add `filterShow` to MetaItems to replace `selected` as selected means "highlighted" throughout now
-  `thumbnailWidth`. `thumbnailHeight` are now just one state value as thumbnails are square
- TileView and TableView only receive the _filtered and sorted_ metadata now, I don't think they care about the full set? (maybe size of full set to show `x of y items shown` in future?)
- 