### PR TITLE
fix: deselect deleted images on props update

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -196,6 +196,11 @@ class UserInterface extends Component<Props, State> {
           ...mitem,
           filterShow: true,
         })),
+        selectedImagesUid: new Set( // deselect images that have been deleted
+          [...this.state.selectedImagesUid.values()].filter((id: string) =>
+            this.props.metadata.map((mitem) => mitem.id).includes(id)
+          )
+        ),
         defaultLabels: this.props.defaultLabels || oldState.defaultLabels,
         restrictLabels: this.props.restrictLabels,
         multiLabel: this.props.multiLabel,
@@ -771,7 +776,7 @@ class UserInterface extends Component<Props, State> {
                           <ViewAnnotationsDialog
                             users={this.props.profiles
                               .filter((profile) =>
-                                this.props.metadata
+                                this.state.metadata
                                   .find(
                                     (mitem) =>
                                       mitem.id ===


### PR DESCRIPTION
## Description

Fixes the crash that happens when deleting an image. Was happening because `this.state.selectedImagesUid` wasn't updating when images were deleted, so it was still trying to find a selected image that no longer existed, getting `undefined` from `find`, and passing that into `MetadataDrawer`. Rather than deselect the image when the callback is fired, which still allows the crash to happen if for some reason the user re-selects the image before it disappears, I've gone with updating `selectedImagesUid` in `componentDidUpdate` when the props change.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
