### PR TITLE
feat: second username box in ViewAnnotationsDialog

### DIFF
--- a/src/components/Tooltips.ts
+++ b/src/components/Tooltips.ts
@@ -77,8 +77,12 @@ const tooltips: Tooltips = {
     name: "Set default labels",
     icon: icons.annotationLabels,
   },
-  viewAnnotations: {
-    name: "View Annotations",
+  viewAnnotation: {
+    name: "View Annotation",
+    icon: icons.imageViewer,
+  },
+  compareAnnotations: {
+    name: "Compare Annotations",
     icon: icons.imageViewer,
   },
 };

--- a/src/components/ViewAnnotationsDialog.tsx
+++ b/src/components/ViewAnnotationsDialog.tsx
@@ -8,17 +8,22 @@ import {
   Box,
   Autocomplete,
   TextField,
+  Typography,
 } from "@gliff-ai/style";
 import { tooltips } from "@/components";
 
 interface Props {
   users: { label: string; email: string }[];
-  annotateCallback: (username: string) => void;
+  annotateCallback: (username1: string, username2: string) => void;
 }
 
 export function ViewAnnotationsDialog(props: Props): React.ReactElement {
   const [username1, setUsername1] = useState<{ label: string; email: string }>({
     label: "",
+    email: "",
+  });
+  const [username2, setUsername2] = useState<{ label: string; email: string }>({
+    label: "Nobody",
     email: "",
   });
   const [close, setClose] = useState<boolean>(false);
@@ -54,7 +59,7 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
           renderInput={(params) => (
             <TextField
               {...params}
-              label="User email"
+              label="User"
               autoFocus
               sx={{
                 fontSize: 14,
@@ -63,6 +68,29 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
             />
           )}
           options={props.users}
+          fullWidth
+        />
+
+        <Typography sx={{ marginBottom: "20px" }}>Compare with:</Typography>
+
+        <Autocomplete
+          onChange={(event, value) => {
+            setUsername2(value as { label: string; email: string });
+          }}
+          key="input-user2"
+          placeholder=""
+          value={username2}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              label="User"
+              sx={{
+                fontSize: 14,
+                marginBottom: "20px",
+              }}
+            />
+          )}
+          options={[...props.users, { label: "Nobody", email: "" }]}
           fullWidth
         />
 
@@ -88,7 +116,7 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
             }
             text="Confirm"
             onClick={() => {
-              props.annotateCallback(username1.email);
+              props.annotateCallback(username1.email, username2.email);
             }}
           />
         </Box>

--- a/src/components/ViewAnnotationsDialog.tsx
+++ b/src/components/ViewAnnotationsDialog.tsx
@@ -15,6 +15,7 @@ import { tooltips } from "@/components";
 interface Props {
   users: { label: string; email: string }[];
   annotateCallback: (username1: string, username2: string) => void;
+  compare: boolean; // if true, render two autocompletes and pass two usernames to annotateCallback
 }
 
 export function ViewAnnotationsDialog(props: Props): React.ReactElement {
@@ -23,7 +24,7 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
     email: "",
   });
   const [username2, setUsername2] = useState<{ label: string; email: string }>({
-    label: "Nobody",
+    label: "",
     email: "",
   });
   const [close, setClose] = useState<boolean>(false);
@@ -40,15 +41,25 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
       title="View Annotations"
       TriggerButton={
         <IconButton
-          icon={icons.showHidePassword}
-          tooltip={tooltips.viewAnnotations}
+          icon={props.compare ? icons.convert : icons.showHidePassword}
+          tooltip={
+            props.compare
+              ? tooltips.compareAnnotations
+              : tooltips.viewAnnotation
+          }
           size="small"
-          id="view-annotations"
+          id={props.compare ? "id-compare-annotations" : "id-view-annotations"}
         />
       }
       close={close}
     >
       <Box sx={{ width: "400px" }}>
+        <Typography sx={{ marginBottom: "20px" }}>
+          {props.compare
+            ? "Select two assignees to compare their annotations for this image."
+            : "Select an assignee to view their annotation for this image."}
+        </Typography>
+
         <Autocomplete
           onChange={(event, value) => {
             setUsername1(value as { label: string; email: string });
@@ -59,7 +70,7 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
           renderInput={(params) => (
             <TextField
               {...params}
-              label="User"
+              label={props.compare ? "User 1" : "User"}
               autoFocus
               sx={{
                 fontSize: 14,
@@ -71,28 +82,28 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
           fullWidth
         />
 
-        <Typography sx={{ marginBottom: "20px" }}>Compare with:</Typography>
-
-        <Autocomplete
-          onChange={(event, value) => {
-            setUsername2(value as { label: string; email: string });
-          }}
-          key="input-user2"
-          placeholder=""
-          value={username2}
-          renderInput={(params) => (
-            <TextField
-              {...params}
-              label="User"
-              sx={{
-                fontSize: 14,
-                marginBottom: "20px",
-              }}
-            />
-          )}
-          options={[...props.users, { label: "Nobody", email: "" }]}
-          fullWidth
-        />
+        {props.compare && (
+          <Autocomplete
+            onChange={(event, value) => {
+              setUsername2(value as { label: string; email: string });
+            }}
+            key="input-user2"
+            placeholder=""
+            value={username2}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label={props.compare ? "User 2" : "User"}
+                sx={{
+                  fontSize: 14,
+                  marginBottom: "20px",
+                }}
+              />
+            )}
+            options={props.users}
+            fullWidth
+          />
+        )}
 
         <Box
           sx={{
@@ -112,11 +123,17 @@ export function ViewAnnotationsDialog(props: Props): React.ReactElement {
           <BaseTextButton
             id="confirm-view-annotations"
             disabled={
-              !props.users.map((user) => user.email).includes(username1?.email)
+              !props.users
+                .map((user) => user.email)
+                .includes(username1?.email) ||
+              (props.compare &&
+                !props.users
+                  .map((user) => user.email)
+                  .includes(username2?.email))
             }
             text="Confirm"
             onClick={() => {
-              props.annotateCallback(username1.email, username2.email);
+              props.annotateCallback(username1.email, username2.email); // username2.email will be "" when compare===false, which will have the same effect as not passing it
             }}
           />
         </Box>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -81,7 +81,11 @@ interface Props {
     newAssignees: string[][]
   ) => void;
   deleteImagesCallback?: (imageUids: string[]) => void;
-  annotateCallback?: (imageUid: string, username?: string) => void;
+  annotateCallback?: (
+    imageUid: string,
+    username1?: string,
+    usernam2?: string
+  ) => void;
   downloadDatasetCallback?: () => void;
   // eslint-disable-next-line react/no-unused-prop-types
   setTask?: (task: {
@@ -790,12 +794,16 @@ class UserInterface extends Component<Props, State> {
                                 label: `${profile.name} - ${profile.email}`,
                                 email: profile.email,
                               }))}
-                            annotateCallback={(username: string) =>
+                            annotateCallback={(
+                              username1: string,
+                              username2: string
+                            ) =>
                               this.props.annotateCallback(
                                 [
                                   ...this.state.selectedImagesUid.values(),
                                 ].pop(),
-                                username
+                                username1,
+                                username2
                               )
                             }
                           />

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -697,6 +697,24 @@ class UserInterface extends Component<Props, State> {
     );
     this.isOwnerOrMember();
 
+    const selectedImageAssignees =
+      this.state.selectedImagesUid.size === 1
+        ? this.props.profiles
+            .filter((profile) =>
+              this.state.metadata
+                .find(
+                  (mitem) =>
+                    mitem.id ===
+                    [...this.state.selectedImagesUid.values()].pop()
+                )
+                .assignees.includes(profile.email)
+            )
+            .map((profile) => ({
+              label: `${profile.name} - ${profile.email}`,
+              email: profile.email,
+            }))
+        : [];
+
     return (
       <StylesProvider generateClassName={generateClassName("curate")}>
         <StyledEngineProvider injectFirst>
@@ -773,27 +791,12 @@ class UserInterface extends Component<Props, State> {
                     this.isOwnerOrMember() && (
                       <Box
                         display="flex"
-                        justifyContent="left"
+                        justifyContent="flex-end"
                         sx={{ marginTop: "10px" }}
                       >
                         <MuiCard>
                           <ViewAnnotationsDialog
-                            users={this.props.profiles
-                              .filter((profile) =>
-                                this.state.metadata
-                                  .find(
-                                    (mitem) =>
-                                      mitem.id ===
-                                      [
-                                        ...this.state.selectedImagesUid.values(),
-                                      ].pop()
-                                  )
-                                  .assignees.includes(profile.email)
-                              )
-                              .map((profile) => ({
-                                label: `${profile.name} - ${profile.email}`,
-                                email: profile.email,
-                              }))}
+                            users={selectedImageAssignees}
                             annotateCallback={(
                               username1: string,
                               username2: string
@@ -806,6 +809,25 @@ class UserInterface extends Component<Props, State> {
                                 username2
                               )
                             }
+                            compare={false}
+                          />
+                        </MuiCard>
+                        <MuiCard sx={{ marginLeft: "10px" }}>
+                          <ViewAnnotationsDialog
+                            users={selectedImageAssignees}
+                            annotateCallback={(
+                              username1: string,
+                              username2: string
+                            ) =>
+                              this.props.annotateCallback(
+                                [
+                                  ...this.state.selectedImagesUid.values(),
+                                ].pop(),
+                                username1,
+                                username2
+                              )
+                            }
+                            compare
                           />
                         </MuiCard>
                       </Box>


### PR DESCRIPTION
## Description

Adds the second username box in ViewAnnotationsDialog, and passes the second username to `annotateCallback`. The second username box has "Nobody" as its default value, which will launch ANNOTATE in single image readonly mode if left unchanged.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
